### PR TITLE
Removed `@Inject` from DataSources' constructors.

### DIFF
--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksLocalDataSource.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksLocalDataSource.java
@@ -43,7 +43,6 @@ public class TasksLocalDataSource implements TasksDataSource {
 
     private TasksDbHelper mDbHelper;
 
-    @Inject
     public TasksLocalDataSource(@NonNull Context context) {
         checkNotNull(context);
         mDbHelper = new TasksDbHelper(context);

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/remote/TasksRemoteDataSource.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/remote/TasksRemoteDataSource.java
@@ -46,7 +46,6 @@ public class TasksRemoteDataSource implements TasksDataSource {
         addTask("Finish bridge in Tacoma", "Found awesome girders at half the cost!");
     }
 
-    @Inject
     public TasksRemoteDataSource() {}
 
     private static void addTask(String title, String description) {


### PR DESCRIPTION
`TasksLocalDataSource` and `TasksRemoteDataSource` don't required `@Inject`, since they are provided with via `TasksRepositoryModule`.

This is a very small issue, so I decided to open PR directly.