### PR TITLE
private constructor to prevent instantiating

### DIFF
--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksPersistenceContract.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksPersistenceContract.java
@@ -25,7 +25,7 @@ public final class TasksPersistenceContract {
 
     // To prevent someone from accidentally instantiating the contract class,
     // give it an empty constructor.
-    public TasksPersistenceContract() {}
+    private TasksPersistenceContract() {}
 
     /* Inner class that defines the table contents */
     public static abstract class TaskEntry implements BaseColumns {


### PR DESCRIPTION
To prevent accidental instantiating the contract class constructor must be private.