### PR TITLE
Remove incorrectly used checkNotNull() method calls

### DIFF
--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskActivity.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskActivity.java
@@ -28,6 +28,8 @@ import com.example.android.architecture.blueprints.todoapp.R;
 import com.example.android.architecture.blueprints.todoapp.util.ActivityUtils;
 import com.example.android.architecture.blueprints.todoapp.util.EspressoIdlingResource;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
  * Displays an add or edit task screen.
  */
@@ -44,6 +46,7 @@ public class AddEditTaskActivity extends AppCompatActivity {
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
         ActionBar actionBar = getSupportActionBar();
+        checkNotNull(actionBar);
         actionBar.setDisplayHomeAsUpEnabled(true);
         actionBar.setDisplayShowHomeEnabled(true);
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.java
@@ -30,8 +30,6 @@ import android.widget.TextView;
 
 import com.example.android.architecture.blueprints.todoapp.R;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 /**
  * Main UI for the add task screen. Users can enter a task title and description.
  */
@@ -63,7 +61,7 @@ public class AddEditTaskFragment extends Fragment implements AddEditTaskContract
 
     @Override
     public void setPresenter(@NonNull AddEditTaskContract.Presenter presenter) {
-        mPresenter = checkNotNull(presenter);
+        mPresenter = presenter;
     }
 
     @Override

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskPresenter.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskPresenter.java
@@ -22,8 +22,6 @@ import android.support.annotation.Nullable;
 import com.example.android.architecture.blueprints.todoapp.data.Task;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksDataSource;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 /**
  * Listens to user actions from the UI ({@link AddEditTaskFragment}), retrieves the data and updates
  * the UI as required.
@@ -50,8 +48,8 @@ public class AddEditTaskPresenter implements AddEditTaskContract.Presenter,
     public AddEditTaskPresenter(@Nullable String taskId, @NonNull TasksDataSource tasksRepository,
             @NonNull AddEditTaskContract.View addTaskView) {
         mTaskId = taskId;
-        mTasksRepository = checkNotNull(tasksRepository);
-        mAddTaskView = checkNotNull(addTaskView);
+        mTasksRepository = tasksRepository;
+        mAddTaskView = addTaskView;
 
         mAddTaskView.setPresenter(this);
     }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.java
@@ -94,8 +94,6 @@ public class TasksRepository implements TasksDataSource {
      */
     @Override
     public void getTasks(@NonNull final LoadTasksCallback callback) {
-        checkNotNull(callback);
-
         // Respond immediately with cache if available and not dirty
         if (mCachedTasks != null && !mCacheIsDirty) {
             callback.onTasksLoaded(new ArrayList<>(mCachedTasks.values()));
@@ -124,7 +122,6 @@ public class TasksRepository implements TasksDataSource {
 
     @Override
     public void saveTask(@NonNull Task task) {
-        checkNotNull(task);
         mTasksRemoteDataSource.saveTask(task);
         mTasksLocalDataSource.saveTask(task);
 
@@ -137,7 +134,6 @@ public class TasksRepository implements TasksDataSource {
 
     @Override
     public void completeTask(@NonNull Task task) {
-        checkNotNull(task);
         mTasksRemoteDataSource.completeTask(task);
         mTasksLocalDataSource.completeTask(task);
 
@@ -152,13 +148,11 @@ public class TasksRepository implements TasksDataSource {
 
     @Override
     public void completeTask(@NonNull String taskId) {
-        checkNotNull(taskId);
         completeTask(getTaskWithId(taskId));
     }
 
     @Override
     public void activateTask(@NonNull Task task) {
-        checkNotNull(task);
         mTasksRemoteDataSource.activateTask(task);
         mTasksLocalDataSource.activateTask(task);
 
@@ -204,9 +198,6 @@ public class TasksRepository implements TasksDataSource {
      */
     @Override
     public void getTask(@NonNull final String taskId, @NonNull final GetTaskCallback callback) {
-        checkNotNull(taskId);
-        checkNotNull(callback);
-
         Task cachedTask = getTaskWithId(taskId);
 
         // Respond immediately with cache if available
@@ -301,7 +292,6 @@ public class TasksRepository implements TasksDataSource {
 
     @Nullable
     private Task getTaskWithId(@NonNull String id) {
-        checkNotNull(id);
         if (mCachedTasks == null || mCachedTasks.isEmpty()) {
             return null;
         } else {

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksLocalDataSource.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksLocalDataSource.java
@@ -43,7 +43,6 @@ public class TasksLocalDataSource implements TasksDataSource {
 
     // Prevent direct instantiation.
     private TasksLocalDataSource(@NonNull Context context) {
-        checkNotNull(context);
         mDbHelper = new TasksDbHelper(context);
     }
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsFragment.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsFragment.java
@@ -27,8 +27,6 @@ import android.widget.TextView;
 
 import com.example.android.architecture.blueprints.todoapp.R;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 /**
  * Main UI for the statistics screen.
  */
@@ -44,7 +42,7 @@ public class StatisticsFragment extends Fragment implements StatisticsContract.V
 
     @Override
     public void setPresenter(@NonNull StatisticsContract.Presenter presenter) {
-        mPresenter = checkNotNull(presenter);
+        mPresenter = presenter;
     }
 
     @Nullable

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsPresenter.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsPresenter.java
@@ -25,8 +25,6 @@ import com.example.android.architecture.blueprints.todoapp.util.EspressoIdlingRe
 
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 /**
  * Listens to user actions from the UI ({@link StatisticsFragment}), retrieves the data and updates
  * the UI as required.
@@ -39,8 +37,8 @@ public class StatisticsPresenter implements StatisticsContract.Presenter {
 
     public StatisticsPresenter(@NonNull TasksRepository tasksRepository,
                                @NonNull StatisticsContract.View statisticsView) {
-        mTasksRepository = checkNotNull(tasksRepository, "tasksRepository cannot be null");
-        mStatisticsView = checkNotNull(statisticsView, "StatisticsView cannot be null!");
+        mTasksRepository = tasksRepository;
+        mStatisticsView = statisticsView;
 
         mStatisticsView.setPresenter(this);
     }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.java
@@ -16,8 +16,6 @@
 
 package com.example.android.architecture.blueprints.todoapp.taskdetail;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
@@ -97,7 +95,7 @@ public class TaskDetailFragment extends Fragment implements TaskDetailContract.V
 
     @Override
     public void setPresenter(@NonNull TaskDetailContract.Presenter presenter) {
-        mPresenter = checkNotNull(presenter);
+        mPresenter = presenter;
     }
 
     @Override

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailPresenter.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailPresenter.java
@@ -23,8 +23,6 @@ import com.example.android.architecture.blueprints.todoapp.data.Task;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksDataSource;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepository;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 /**
  * Listens to user actions from the UI ({@link TaskDetailFragment}), retrieves the data and updates
  * the UI as required.
@@ -42,8 +40,8 @@ public class TaskDetailPresenter implements TaskDetailContract.Presenter {
                                @NonNull TasksRepository tasksRepository,
                                @NonNull TaskDetailContract.View taskDetailView) {
         this.mTaskId = taskId;
-        mTasksRepository = checkNotNull(tasksRepository, "tasksRepository cannot be null!");
-        mTaskDetailView = checkNotNull(taskDetailView, "taskDetailView cannot be null!");
+        mTasksRepository = tasksRepository;
+        mTaskDetailView = taskDetailView;
 
         mTaskDetailView.setPresenter(this);
     }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.java
@@ -92,7 +92,7 @@ public class TasksFragment extends Fragment implements TasksContract.View {
 
     @Override
     public void setPresenter(@NonNull TasksContract.Presenter presenter) {
-        mPresenter = checkNotNull(presenter);
+        mPresenter = presenter;
     }
 
     @Override

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksPresenter.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksPresenter.java
@@ -45,8 +45,8 @@ public class TasksPresenter implements TasksContract.Presenter {
     private boolean mFirstLoad = true;
 
     public TasksPresenter(@NonNull TasksRepository tasksRepository, @NonNull TasksContract.View tasksView) {
-        mTasksRepository = checkNotNull(tasksRepository, "tasksRepository cannot be null");
-        mTasksView = checkNotNull(tasksView, "tasksView cannot be null!");
+        mTasksRepository = tasksRepository;
+        mTasksView = tasksView;
 
         mTasksView.setPresenter(this);
     }
@@ -189,13 +189,11 @@ public class TasksPresenter implements TasksContract.Presenter {
 
     @Override
     public void openTaskDetails(@NonNull Task requestedTask) {
-        checkNotNull(requestedTask, "requestedTask cannot be null!");
         mTasksView.showTaskDetailsUi(requestedTask.getId());
     }
 
     @Override
     public void completeTask(@NonNull Task completedTask) {
-        checkNotNull(completedTask, "completedTask cannot be null!");
         mTasksRepository.completeTask(completedTask);
         mTasksView.showTaskMarkedComplete();
         loadTasks(false, false);
@@ -203,7 +201,6 @@ public class TasksPresenter implements TasksContract.Presenter {
 
     @Override
     public void activateTask(@NonNull Task activeTask) {
-        checkNotNull(activeTask, "activeTask cannot be null!");
         mTasksRepository.activateTask(activeTask);
         mTasksView.showTaskMarkedActive();
         loadTasks(false, false);

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/util/ActivityUtils.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/util/ActivityUtils.java
@@ -21,8 +21,6 @@ import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 /**
  * This provides methods to help Activities load their UI.
  */
@@ -35,8 +33,6 @@ public class ActivityUtils {
      */
     public static void addFragmentToActivity (@NonNull FragmentManager fragmentManager,
                                               @NonNull Fragment fragment, int frameId) {
-        checkNotNull(fragmentManager);
-        checkNotNull(fragment);
         FragmentTransaction transaction = fragmentManager.beginTransaction();
         transaction.add(frameId, fragment);
         transaction.commit();

--- a/todoapp/app/src/mock/java/com/example/android/architecture/blueprints/todoapp/Injection.java
+++ b/todoapp/app/src/mock/java/com/example/android/architecture/blueprints/todoapp/Injection.java
@@ -34,7 +34,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class Injection {
 
     public static TasksRepository provideTasksRepository(@NonNull Context context) {
-        checkNotNull(context);
         return TasksRepository.getInstance(FakeTasksRemoteDataSource.getInstance(),
                 TasksLocalDataSource.getInstance(context));
     }

--- a/todoapp/app/src/prod/java/com/example/android/architecture/blueprints/todoapp/Injection.java
+++ b/todoapp/app/src/prod/java/com/example/android/architecture/blueprints/todoapp/Injection.java
@@ -33,7 +33,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class Injection {
 
     public static TasksRepository provideTasksRepository(@NonNull Context context) {
-        checkNotNull(context);
         return TasksRepository.getInstance(TasksRemoteDataSource.getInstance(),
                 TasksLocalDataSource.getInstance(context));
     }


### PR DESCRIPTION
If some object has @NonNull annotation it tells it can't be null. `checkNotNull()` calls with that annotation are redundant and misleading.  #110