### PR TITLE
Cache getTask() result

### DIFF
--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.java
@@ -221,6 +221,7 @@ public class TasksRepository implements TasksDataSource {
         mTasksLocalDataSource.getTask(taskId, new GetTaskCallback() {
             @Override
             public void onTaskLoaded(Task task) {
+                mCachedTasks.put(task.getId(), task);
                 callback.onTaskLoaded(task);
             }
 
@@ -229,6 +230,7 @@ public class TasksRepository implements TasksDataSource {
                 mTasksRemoteDataSource.getTask(taskId, new GetTaskCallback() {
                     @Override
                     public void onTaskLoaded(Task task) {
+                        mCachedTasks.put(task.getId(), task);
                         callback.onTaskLoaded(task);
                     }
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.java
@@ -221,6 +221,10 @@ public class TasksRepository implements TasksDataSource {
         mTasksLocalDataSource.getTask(taskId, new GetTaskCallback() {
             @Override
             public void onTaskLoaded(Task task) {
+                // Do in memory cache update to keep the app UI up to date
+                if (mCachedTasks == null) {
+                    mCachedTasks = new LinkedHashMap<>();
+                }
                 mCachedTasks.put(task.getId(), task);
                 callback.onTaskLoaded(task);
             }
@@ -230,6 +234,10 @@ public class TasksRepository implements TasksDataSource {
                 mTasksRemoteDataSource.getTask(taskId, new GetTaskCallback() {
                     @Override
                     public void onTaskLoaded(Task task) {
+                        // Do in memory cache update to keep the app UI up to date
+                        if (mCachedTasks == null) {
+                            mCachedTasks = new LinkedHashMap<>();
+                        }
                         mCachedTasks.put(task.getId(), task);
                         callback.onTaskLoaded(task);
                     }


### PR DESCRIPTION
In ```TasksRepository``` a task is loaded with ```mTasksRemoteDataSource.getTask()``` and ```mTasksLocalDataSource.getTask()``` - but the task isn't cached.
With this PR the loaded task is cached in the provided map ```mCachedTasks```.

I noticed this in the branches todo-mvp and dev-todo-mvp-clean-rxjava (@NikitaKozlov).