### PR TITLE
Proposed extension of RxJava usage across all layers of the MVP

### DIFF
--- a/todoapp/app/build.gradle
+++ b/todoapp/app/build.gradle
@@ -1,8 +1,14 @@
 apply plugin: 'com.android.application'
+apply plugin: 'me.tatarka.retrolambda'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 
     defaultConfig {
         applicationId "com.example.android.architecture.blueprints.todomvp"
@@ -72,6 +78,10 @@ dependencies {
     compile "com.google.guava:guava:$rootProject.guavaVersion"
     compile "io.reactivex:rxjava:$rootProject.rxjavaVersion"
     compile "io.reactivex:rxandroid:$rootProject.rxandroidVersion"
+    compile "com.jakewharton.rxrelay:rxrelay:$rootProject.rxrelayVersion"
+    compile "com.jakewharton.rxbinding:rxbinding:$rootProject.rxbindingVersion"
+    compile "com.jakewharton.rxbinding:rxbinding-support-v4:$rootProject.rxbindingVersion"
+    compile "com.jakewharton.rxbinding:rxbinding-appcompat-v7:$rootProject.rxbindingVersion"
     compile "com.squareup.sqlbrite:sqlbrite:$rootProject.sqlbriteVersion"
 
     // Dependencies for local unit tests

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailContract.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailContract.java
@@ -26,7 +26,7 @@ import rx.Observable;
  */
 public interface TaskDetailContract {
 
-    interface View extends BaseView<Presenter> {
+    interface View extends BaseView<BasePresenter> {
 
         /* User event Observables */
 
@@ -63,11 +63,5 @@ public interface TaskDetailContract {
         void showTaskMarkedActive();
 
         boolean isActive();
-
     }
-
-    // TODO: Consider removing this, since View is the one emitting and receiving signals.
-    interface Presenter extends BasePresenter {
-    }
-
 }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailContract.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailContract.java
@@ -19,12 +19,26 @@ package com.example.android.architecture.blueprints.todoapp.taskdetail;
 import com.example.android.architecture.blueprints.todoapp.BasePresenter;
 import com.example.android.architecture.blueprints.todoapp.BaseView;
 
+import rx.Observable;
+
 /**
  * This specifies the contract between the view and the presenter.
  */
 public interface TaskDetailContract {
 
     interface View extends BaseView<Presenter> {
+
+        /* User event Observables */
+
+        Observable<Void> editTask();
+
+        Observable<Void> deleteTask();
+
+        Observable<Void> completeTask();
+
+        Observable<Void> activateTask();
+
+        /* View update methods */
 
         void setLoadingIndicator(boolean active);
 
@@ -49,16 +63,11 @@ public interface TaskDetailContract {
         void showTaskMarkedActive();
 
         boolean isActive();
+
     }
 
+    // TODO: Consider removing this, since View is the one emitting and receiving signals.
     interface Presenter extends BasePresenter {
-
-        void editTask();
-
-        void deleteTask();
-
-        void completeTask();
-
-        void activateTask();
     }
+
 }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.java
@@ -33,6 +33,7 @@ import android.view.ViewGroup;
 import android.widget.CheckBox;
 import android.widget.TextView;
 
+import com.example.android.architecture.blueprints.todoapp.BasePresenter;
 import com.example.android.architecture.blueprints.todoapp.R;
 import com.example.android.architecture.blueprints.todoapp.addedittask.AddEditTaskActivity;
 import com.example.android.architecture.blueprints.todoapp.addedittask.AddEditTaskFragment;
@@ -42,8 +43,6 @@ import com.jakewharton.rxbinding.widget.RxCompoundButton;
 import com.jakewharton.rxrelay.PublishRelay;
 
 import rx.Observable;
-import rx.Subscription;
-import rx.subscriptions.CompositeSubscription;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -56,7 +55,7 @@ public class TaskDetailFragment extends Fragment implements TaskDetailContract.V
 
     public static final int REQUEST_EDIT_TASK = 1;
 
-    private TaskDetailContract.Presenter mPresenter;
+    private BasePresenter mPresenter;
 
     private TextView mDetailTitle;
 
@@ -113,7 +112,7 @@ public class TaskDetailFragment extends Fragment implements TaskDetailContract.V
         mEditTaskClick = RxView.clicks(fab);
         mCheckedChanges = RxCompoundButton
                 .checkedChanges(mDetailCompleteStatus)
-                .doOnNext(checked-> Log.i("TEST","Pre-UpdatingFilter "+checked))
+                .doOnNext(checked -> Log.i("TEST", "Pre-UpdatingFilter " + checked))
                 .filter(checked -> !mUpdating)
                 .share();
 
@@ -121,7 +120,7 @@ public class TaskDetailFragment extends Fragment implements TaskDetailContract.V
     }
 
     @Override
-    public void setPresenter(@NonNull TaskDetailContract.Presenter presenter) {
+    public void setPresenter(@NonNull BasePresenter presenter) {
         mPresenter = checkNotNull(presenter);
     }
 
@@ -233,7 +232,7 @@ public class TaskDetailFragment extends Fragment implements TaskDetailContract.V
     @Override
     public Observable<Void> completeTask() {
         return mCheckedChanges
-                .doOnNext(checked-> Log.i("TEST",""+checked))
+                .doOnNext(checked -> Log.i("TEST", "" + checked))
                 .filter(checked -> checked)
                 .map(checked -> (Void) null);
     }
@@ -241,7 +240,7 @@ public class TaskDetailFragment extends Fragment implements TaskDetailContract.V
     @Override
     public Observable<Void> activateTask() {
         return mCheckedChanges
-                .doOnNext(checked-> Log.i("TEST",""+checked))
+                .doOnNext(checked -> Log.i("TEST", "" + checked))
                 .filter(checked -> !checked)
                 .map(checked -> (Void) null);
     }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailPresenter.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailPresenter.java
@@ -80,7 +80,7 @@ public class TaskDetailPresenter implements TaskDetailContract.Presenter {
         }
 
         mTaskDetailView.setLoadingIndicator(true);
-        Subscription subscription = mTasksRepository
+        Subscription repoSubscription = mTasksRepository
                 .getTask(mTaskId)
                 .subscribeOn(mSchedulerProvider.computation())
                 .observeOn(mSchedulerProvider.ui())
@@ -100,11 +100,30 @@ public class TaskDetailPresenter implements TaskDetailContract.Presenter {
                         showTask(task);
                     }
                 });
-        mSubscriptions.add(subscription);
+        mSubscriptions.add(repoSubscription);
+
+        Subscription editSubscription = mTaskDetailView
+                .editTask()
+                .subscribe(aVoid -> editTask());
+        mSubscriptions.add(editSubscription);
+
+        Subscription deleteSubscription = mTaskDetailView
+                .deleteTask()
+                .subscribe(aVoid -> deleteTask());
+        mSubscriptions.add(deleteSubscription);
+
+        Subscription completeSubscription = mTaskDetailView
+                .completeTask()
+                .subscribe(aVoid -> completeTask());
+        mSubscriptions.add(completeSubscription);
+
+        Subscription activateSubscription = mTaskDetailView
+                .activateTask()
+                .subscribe(aVoid -> activateTask());
+        mSubscriptions.add(activateSubscription);
     }
 
-    @Override
-    public void editTask() {
+    private void editTask() {
         if (null == mTaskId || mTaskId.isEmpty()) {
             mTaskDetailView.showMissingTask();
             return;
@@ -112,14 +131,12 @@ public class TaskDetailPresenter implements TaskDetailContract.Presenter {
         mTaskDetailView.showEditTask(mTaskId);
     }
 
-    @Override
-    public void deleteTask() {
+    private void deleteTask() {
         mTasksRepository.deleteTask(mTaskId);
         mTaskDetailView.showTaskDeleted();
     }
 
-    @Override
-    public void completeTask() {
+    private void completeTask() {
         if (null == mTaskId || mTaskId.isEmpty()) {
             mTaskDetailView.showMissingTask();
             return;
@@ -128,8 +145,7 @@ public class TaskDetailPresenter implements TaskDetailContract.Presenter {
         mTaskDetailView.showTaskMarkedComplete();
     }
 
-    @Override
-    public void activateTask() {
+    private void activateTask() {
         if (null == mTaskId || mTaskId.isEmpty()) {
             mTaskDetailView.showMissingTask();
             return;

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailPresenter.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailPresenter.java
@@ -19,6 +19,7 @@ package com.example.android.architecture.blueprints.todoapp.taskdetail;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.example.android.architecture.blueprints.todoapp.BasePresenter;
 import com.example.android.architecture.blueprints.todoapp.data.Task;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepository;
 import com.example.android.architecture.blueprints.todoapp.util.schedulers.BaseSchedulerProvider;
@@ -33,7 +34,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Listens to user actions from the UI ({@link TaskDetailFragment}), retrieves the data and updates
  * the UI as required.
  */
-public class TaskDetailPresenter implements TaskDetailContract.Presenter {
+public class TaskDetailPresenter implements BasePresenter {
 
     @NonNull
     private final TasksRepository mTasksRepository;

--- a/todoapp/build.gradle
+++ b/todoapp/build.gradle
@@ -5,6 +5,10 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.0-beta1'
 
+        // Retrolambda Support
+        classpath 'me.tatarka:gradle-retrolambda:3.2.5'
+        classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -23,7 +27,7 @@ task clean(type: Delete) {
 // Define versions in a single place
 ext {
     // Sdk and tools
-    minSdkVersion = 10
+    minSdkVersion = 14
     targetSdkVersion = 22
     compileSdkVersion = 23
     buildToolsVersion = '23.0.2'
@@ -40,5 +44,7 @@ ext {
     espressoVersion = '2.2.1'
     rxjavaVersion = '1.1.8'
     rxandroidVersion = '1.2.1'
+    rxrelayVersion = '1.1.0'
+    rxbindingVersion = '0.4.0'
     sqlbriteVersion = '0.7.0'
 }


### PR DESCRIPTION
I've built a small example of how we could use RxJava across the View/Presenter bridge. Benefits include the possibility of writing Presenter tests as observable chains, cleaner observable chain building in the presenter (allows for debouncing, more sophisticated UX behavior, etc.)

Small note on the change to the Contract, I've moved the emitting Observable to the view side. I believe this still respects the MVP model, based on this model:

![image](https://cloud.githubusercontent.com/assets/1449618/18011483/68139072-6b83-11e6-9493-30fc6d5b9fc4.png)

Notes:

- Changes to contract to reflect View's emitter/consumer nature when using Observables.
- Example of using RxRelay to hide implementation details / lifecycle issues from presenter.
- Example of using RxBindings on View side.
- Added RetroLambda support.

