### PR TITLE
Synchronize the SheduleProvider#getInstance method to make it thread safe.

### DIFF
--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/util/schedulers/SchedulerProvider.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/util/schedulers/SchedulerProvider.java
@@ -19,7 +19,7 @@ public class SchedulerProvider implements BaseSchedulerProvider {
     private SchedulerProvider() {
     }
 
-    public static SchedulerProvider getInstance() {
+    public static synchronized SchedulerProvider getInstance() {
         if (INSTANCE == null) {
             INSTANCE = new SchedulerProvider();
         }


### PR DESCRIPTION
As par the discussion on #174, changed the getInstance method as synchronized.

(Sorry I closed the #174 accidentally and couldn't find a way to amend the PR. I'm sending another PR)