### PR TITLE
Clicking outside of the task list was causing a pull down refresh

### DIFF
--- a/todoapp/app/src/main/res/layout/tasks_frag.xml
+++ b/todoapp/app/src/main/res/layout/tasks_frag.xml
@@ -23,6 +23,7 @@
         android:id="@+id/tasksContainer"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:clickable="true"
         android:orientation="vertical">
 
         <LinearLayout


### PR DESCRIPTION
By making the tasksContainer layout clickable, the click is consumed by that layout before it propagates to the SwipeRefreshLayout.