### PR TITLE
Adding CircleCI configuration file circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,16 @@
+machine:
+  java:
+    version: oraclejdk8
+
+dependencies:
+  pre:
+    - echo y | android update sdk --no-ui --all --filter "tools,platform-tools,build-tools-24.0.2,android-24,extra-android-m2repository"
+  override:
+    - cd todoapp;./gradlew dependencies
+  post:
+    - rm -f ~/.gradle/caches/modules-2/modules-2.lock
+
+test:
+  override:
+    - cd todoapp;./gradlew test
+    - cp -r todoapp/app/build/test-results/* $CIRCLE_TEST_REPORTS


### PR DESCRIPTION
fix #209 
## What is different from [Travis](https://github.com/googlesamples/android-architecture/blob/todo-mvp/.travis.yml):
### Cache
- CircleCI will [automatically cache `.m2` and `.gradle` folders](https://circleci.com/docs/how-cache-works/) so did not include them in the config file.
- Also, CircleCI does not cache folder after the tests are run but [before](https://discuss.circleci.com/t/gradle-build-phase/1287/3). Hence the addition of the `./gradlew dependencies` step to allow the dependencies to actually get cached.
### Test Reports
- CircleCI supports it so I save the reports in the corresponding folder.
### Misc
- I use `cd todoapp;./gradlew xxx` oneliner because directory changes are reset on every step.
- Not sure why there was the `rm -f ~/.gradle/caches/modules-2/modules-2.lock` line but copied it in case.
