### PR TITLE
Trivial typo in Javadoc

### DIFF
--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.java
@@ -199,7 +199,7 @@ public class TasksRepository implements TasksDataSource {
      * Gets tasks from local data source (sqlite) unless the table is new or empty. In that case it
      * uses the network data source. This is done to simplify the sample.
      * <p>
-     * Note: {@link LoadTasksCallback#onDataNotAvailable()} is fired if both data sources fail to
+     * Note: {@link GetTaskCallback#onDataNotAvailable()} is fired if both data sources fail to
      * get the data.
      */
     @Override


### PR DESCRIPTION
I noticed a trivial typo in the Javadoc for the `getTask()` method in `TasksRepository` in the `todo-mvp` branch. It's present in at least one other branch (`todo-mvp-clean`)

I'm not sure the best way to fix all of them at once, whether I should create a PR for every affected branch, or it's easier for the maintainers to manually correct them.