### PR TITLE
Update ToDoApplication.java

### DIFF
--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/ToDoApplication.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/ToDoApplication.java
@@ -35,7 +35,7 @@ public class ToDoApplication extends Application {
 
         mRepositoryComponent = DaggerTasksRepositoryComponent.builder()
                 .applicationModule(new ApplicationModule((getApplicationContext())))
-                .tasksRepositoryModule(new TasksRepositoryModule()).build();
+                .build();
 
     }
 


### PR DESCRIPTION
We do not need  .tasksRepositoryModule(new TasksRepositoryModule())  cause it does not require external state.