### PR TITLE
[todo-mvp-dagger] Bind TasksDataSource impls using @Bind & @Inject

### DIFF
--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/ToDoApplication.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/ToDoApplication.java
@@ -5,7 +5,6 @@ import android.app.Application;
 import com.example.android.architecture.blueprints.todoapp.addedittask.AddEditTaskComponent;
 import com.example.android.architecture.blueprints.todoapp.data.source.DaggerTasksRepositoryComponent;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepositoryComponent;
-import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepositoryModule;
 import com.example.android.architecture.blueprints.todoapp.statistics.StatisticsComponent;
 import com.example.android.architecture.blueprints.todoapp.taskdetail.TaskDetailComponent;
 import com.example.android.architecture.blueprints.todoapp.tasks.TasksComponent;

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksLocalDataSource.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksLocalDataSource.java
@@ -43,6 +43,7 @@ public class TasksLocalDataSource implements TasksDataSource {
 
     private TasksDbHelper mDbHelper;
 
+    @Inject
     public TasksLocalDataSource(@NonNull Context context) {
         checkNotNull(context);
         mDbHelper = new TasksDbHelper(context);

--- a/todoapp/app/src/mock/java/com/example/android/architecture/blueprints/todoapp/data/FakeTasksRemoteDataSource.java
+++ b/todoapp/app/src/mock/java/com/example/android/architecture/blueprints/todoapp/data/FakeTasksRemoteDataSource.java
@@ -26,6 +26,8 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import javax.inject.Inject;
+
 /**
  * Implementation of a remote data source with static access to the data for easy testing.
  */
@@ -33,6 +35,7 @@ public class FakeTasksRemoteDataSource implements TasksDataSource {
 
     private static final Map<String, Task> TASKS_SERVICE_DATA = new LinkedHashMap<>();
 
+    @Inject
     public FakeTasksRemoteDataSource() {}
 
     @Override

--- a/todoapp/app/src/mock/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepositoryModule.java
+++ b/todoapp/app/src/mock/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepositoryModule.java
@@ -1,33 +1,26 @@
 package com.example.android.architecture.blueprints.todoapp.data.source;
 
-import android.content.Context;
-
 import com.example.android.architecture.blueprints.todoapp.data.FakeTasksRemoteDataSource;
 import com.example.android.architecture.blueprints.todoapp.data.source.local.TasksLocalDataSource;
 
 import javax.inject.Singleton;
 
+import dagger.Binds;
 import dagger.Module;
-import dagger.Provides;
 
 /**
  * This is used by Dagger to inject the required arguments into the {@link TasksRepository}.
  */
 @Module
-public class TasksRepositoryModule {
+abstract class TasksRepositoryModule {
 
     @Singleton
-    @Provides
+    @Binds
     @Local
-    TasksDataSource provideTasksLocalDataSource(Context context) {
-        return new TasksLocalDataSource(context);
-    }
+    abstract TasksDataSource provideTasksLocalDataSource(TasksLocalDataSource dataSource);
 
     @Singleton
-    @Provides
+    @Binds
     @Remote
-    TasksDataSource provideTasksRemoteDataSource() {
-        return new FakeTasksRemoteDataSource();
-    }
-
+    abstract TasksDataSource provideTasksRemoteDataSource(FakeTasksRemoteDataSource dataSource);
 }

--- a/todoapp/build.gradle
+++ b/todoapp/build.gradle
@@ -40,6 +40,6 @@ ext {
     runnerVersion = '0.5'
     rulesVersion = '0.5'
     espressoVersion = '2.2.2'
-    daggerVersion = '2.2'
+    daggerVersion = '2.7'
     dexmakerVersion = '1.2'
 }


### PR DESCRIPTION
Rather than binding FakeTasksRemoteDataSource and TasksLocalDataSource
by direct instantiation in TasksRepositoryModule provider methods,
use abstract @Binds methods to delegate bindings.

This requires upgrading dagger from 2.2 (2.7 is the current version).

Motivation:
1. Boilerplate reduction.
2. Efficiency, from the javadoc (http://google.github.io/dagger/api/latest/dagger/Binds.html):
"Prefer @Binds because the generated implementation is likely to be more efficient."

Further details on @Binds vs @Provides:
http://google.github.io/dagger/faq#why-is-binds-different-from-provides
