### PR TITLE
AddEditTask: adds rotation tests and fixes persistance bug

### DIFF
--- a/todoapp/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksScreenTest.java
+++ b/todoapp/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksScreenTest.java
@@ -16,31 +16,8 @@
 
 package com.example.android.architecture.blueprints.todoapp.tasks;
 
-import static android.support.test.InstrumentationRegistry.getTargetContext;
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
-import static android.support.test.espresso.action.ViewActions.replaceText;
-import static android.support.test.espresso.action.ViewActions.typeText;
-import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.hasSibling;
-import static android.support.test.espresso.matcher.ViewMatchers.isAssignableFrom;
-import static android.support.test.espresso.matcher.ViewMatchers.isChecked;
-import static android.support.test.espresso.matcher.ViewMatchers.isDescendantOfA;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
-
-import static com.example.android.architecture.blueprints.todoapp.TestUtils.getCurrentActivity;
-import static com.google.common.base.Preconditions.checkArgument;
-
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.core.IsNot.not;
-
 import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.SdkSuppress;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.test.suitebuilder.annotation.LargeTest;
@@ -59,6 +36,28 @@ import org.hamcrest.TypeSafeMatcher;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static android.support.test.InstrumentationRegistry.getTargetContext;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static android.support.test.espresso.action.ViewActions.replaceText;
+import static android.support.test.espresso.action.ViewActions.typeText;
+import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.hasSibling;
+import static android.support.test.espresso.matcher.ViewMatchers.isAssignableFrom;
+import static android.support.test.espresso.matcher.ViewMatchers.isChecked;
+import static android.support.test.espresso.matcher.ViewMatchers.isDescendantOfA;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static com.example.android.architecture.blueprints.todoapp.TestUtils.getCurrentActivity;
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.core.IsNot.not;
 
 /**
  * Tests for the tasks screen, the main screen which contains a list of all tasks.
@@ -437,7 +436,35 @@ public class TasksScreenTest {
     }
 
     @Test
-    public void orientationChange_DuringEdit() throws IllegalStateException {
+    @SdkSuppress(minSdkVersion = 21) // Blinking cursor after rotation breaks this in API 19
+    public void orientationChange_DuringEdit_ChangePersists() throws Throwable {
+        // Add a completed task
+        createTask(TITLE1, DESCRIPTION);
+
+        // Open the task in details view
+        onView(withText(TITLE1)).perform(click());
+
+        // Click on the edit task button
+        onView(withId(R.id.fab_edit_task)).perform(click());
+
+        // Edit task title and description
+        onView(withId(R.id.add_task_title))
+                .perform(replaceText(TITLE2), closeSoftKeyboard()); // Type new task title
+
+        // Rotate the screen
+        TestUtils.rotateOrientation(getCurrentActivity());
+
+        onView(withId(R.id.add_task_title)).perform(closeSoftKeyboard());
+
+        // Verify task is displayed on screen in the task list.
+        onView(withId(R.id.add_task_title)).check(matches(withText(TITLE2)));
+        onView(withId(R.id.add_task_description)).check(matches(withText(DESCRIPTION)));
+
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 21) // Blinking cursor after rotation breaks this in API 19
+    public void orientationChange_DuringEdit_NoDuplicate() throws IllegalStateException {
         // Add a completed task
         createTask(TITLE1, DESCRIPTION);
 

--- a/todoapp/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksScreenTest.java
+++ b/todoapp/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksScreenTest.java
@@ -447,19 +447,15 @@ public class TasksScreenTest {
         // Click on the edit task button
         onView(withId(R.id.fab_edit_task)).perform(click());
 
-        // Edit task title and description
+        // Change task title (but don't save)
         onView(withId(R.id.add_task_title))
                 .perform(replaceText(TITLE2), closeSoftKeyboard()); // Type new task title
 
         // Rotate the screen
         TestUtils.rotateOrientation(getCurrentActivity());
 
-        onView(withId(R.id.add_task_title)).perform(closeSoftKeyboard());
-
-        // Verify task is displayed on screen in the task list.
+        // Verify task title is restored
         onView(withId(R.id.add_task_title)).check(matches(withText(TITLE2)));
-        onView(withId(R.id.add_task_description)).check(matches(withText(DESCRIPTION)));
-
     }
 
     @Test

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskActivity.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskActivity.java
@@ -50,6 +50,9 @@ public class AddEditTaskActivity extends AppCompatActivity {
         AddEditTaskFragment addEditTaskFragment =
                 (AddEditTaskFragment) getSupportFragmentManager().findFragmentById(R.id.contentFrame);
 
+        // Prevent the presenter from loading data from the repository if this is a config change.
+        boolean shouldLoadDataFromRepo = addEditTaskFragment == null;
+
         String taskId = getIntent().getStringExtra(AddEditTaskFragment.ARGUMENT_EDIT_TASK_ID);
 
         if (addEditTaskFragment == null) {
@@ -72,7 +75,8 @@ public class AddEditTaskActivity extends AppCompatActivity {
         new AddEditTaskPresenter(
                 taskId,
                 Injection.provideTasksRepository(getApplicationContext()),
-                addEditTaskFragment);
+                addEditTaskFragment,
+                shouldLoadDataFromRepo);
     }
 
     @Override

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskActivity.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskActivity.java
@@ -35,6 +35,10 @@ public class AddEditTaskActivity extends AppCompatActivity {
 
     public static final int REQUEST_ADD_TASK = 1;
 
+    public static final String SHOULD_LOAD_DATA_FROM_REPO_KEY = "SHOULD_LOAD_DATA_FROM_REPO_KEY";
+
+    private AddEditTaskPresenter mAddEditTaskPresenter;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -68,15 +72,29 @@ public class AddEditTaskActivity extends AppCompatActivity {
                     addEditTaskFragment, R.id.contentFrame);
         }
 
+        boolean shouldLoadDataFromRepo = true;
+
         // Prevent the presenter from loading data from the repository if this is a config change.
-        boolean shouldLoadDataFromRepo = addEditTaskFragment == null;
+        if (savedInstanceState != null) {
+            // Data might not have loaded when the config change happen, so we saved the state.
+            shouldLoadDataFromRepo = savedInstanceState.getBoolean(SHOULD_LOAD_DATA_FROM_REPO_KEY);
+        }
 
         // Create the presenter
-        new AddEditTaskPresenter(
+        mAddEditTaskPresenter = new AddEditTaskPresenter(
                 taskId,
                 Injection.provideTasksRepository(getApplicationContext()),
                 addEditTaskFragment,
                 shouldLoadDataFromRepo);
+
+        addEditTaskFragment.setPresenter(mAddEditTaskPresenter);
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        // Save the state so that next time we know if we need to refresh data.
+        outState.putBoolean(SHOULD_LOAD_DATA_FROM_REPO_KEY, mAddEditTaskPresenter.isDataMissing());
+        super.onSaveInstanceState(outState);
     }
 
     @Override

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskActivity.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskActivity.java
@@ -50,9 +50,6 @@ public class AddEditTaskActivity extends AppCompatActivity {
         AddEditTaskFragment addEditTaskFragment =
                 (AddEditTaskFragment) getSupportFragmentManager().findFragmentById(R.id.contentFrame);
 
-        // Prevent the presenter from loading data from the repository if this is a config change.
-        boolean shouldLoadDataFromRepo = addEditTaskFragment == null;
-
         String taskId = getIntent().getStringExtra(AddEditTaskFragment.ARGUMENT_EDIT_TASK_ID);
 
         if (addEditTaskFragment == null) {
@@ -70,6 +67,9 @@ public class AddEditTaskActivity extends AppCompatActivity {
             ActivityUtils.addFragmentToActivity(getSupportFragmentManager(),
                     addEditTaskFragment, R.id.contentFrame);
         }
+
+        // Prevent the presenter from loading data from the repository if this is a config change.
+        boolean shouldLoadDataFromRepo = addEditTaskFragment == null;
 
         // Create the presenter
         new AddEditTaskPresenter(

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskContract.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskContract.java
@@ -42,5 +42,7 @@ public interface AddEditTaskContract {
         void saveTask(String title, String description);
 
         void populateTask();
+
+        boolean isDataMissing();
     }
 }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.java
@@ -86,7 +86,6 @@ public class AddEditTaskFragment extends Fragment implements AddEditTaskContract
         View root = inflater.inflate(R.layout.addtask_frag, container, false);
         mTitle = (TextView) root.findViewById(R.id.add_task_title);
         mDescription = (TextView) root.findViewById(R.id.add_task_description);
-        setRetainInstance(false);
         setHasOptionsMenu(true);
         return root;
     }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.java
@@ -86,9 +86,8 @@ public class AddEditTaskFragment extends Fragment implements AddEditTaskContract
         View root = inflater.inflate(R.layout.addtask_frag, container, false);
         mTitle = (TextView) root.findViewById(R.id.add_task_title);
         mDescription = (TextView) root.findViewById(R.id.add_task_description);
-
+        setRetainInstance(false);
         setHasOptionsMenu(true);
-        setRetainInstance(true);
         return root;
     }
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskPresenter.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskPresenter.java
@@ -40,7 +40,7 @@ public class AddEditTaskPresenter implements AddEditTaskContract.Presenter,
     @Nullable
     private String mTaskId;
 
-    private final boolean mLoadData;
+    private boolean mIsDataMissing;
 
     /**
      * Creates a presenter for the add/edit view.
@@ -48,21 +48,19 @@ public class AddEditTaskPresenter implements AddEditTaskContract.Presenter,
      * @param taskId ID of the task to edit or null for a new task
      * @param tasksRepository a repository of data for tasks
      * @param addTaskView the add/edit view
-     * @param loadData whether data needs to be loaded or not (like after a rotation)
+     * @param shouldLoadDataFromRepo whether data needs to be loaded or not (for config changes)
      */
     public AddEditTaskPresenter(@Nullable String taskId, @NonNull TasksDataSource tasksRepository,
-            @NonNull AddEditTaskContract.View addTaskView, boolean loadData) {
+            @NonNull AddEditTaskContract.View addTaskView, boolean shouldLoadDataFromRepo) {
         mTaskId = taskId;
         mTasksRepository = checkNotNull(tasksRepository);
         mAddTaskView = checkNotNull(addTaskView);
-        mLoadData = loadData;
-
-        mAddTaskView.setPresenter(this);
+        mIsDataMissing = shouldLoadDataFromRepo;q
     }
 
     @Override
     public void start() {
-        if (!isNewTask() && mLoadData) {
+        if (!isNewTask() && mIsDataMissing) {
             populateTask();
         }
     }
@@ -91,6 +89,7 @@ public class AddEditTaskPresenter implements AddEditTaskContract.Presenter,
             mAddTaskView.setTitle(task.getTitle());
             mAddTaskView.setDescription(task.getDescription());
         }
+        mIsDataMissing = false;
     }
 
     @Override
@@ -99,6 +98,11 @@ public class AddEditTaskPresenter implements AddEditTaskContract.Presenter,
         if (mAddTaskView.isActive()) {
             mAddTaskView.showEmptyTaskError();
         }
+    }
+
+    @Override
+    public boolean isDataMissing() {
+        return mIsDataMissing;
     }
 
     private boolean isNewTask() {

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskPresenter.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskPresenter.java
@@ -37,6 +37,8 @@ public class AddEditTaskPresenter implements AddEditTaskContract.Presenter,
     @NonNull
     private final AddEditTaskContract.View mAddTaskView;
 
+    private final boolean mLoadData;
+
     @Nullable
     private String mTaskId;
 
@@ -48,17 +50,18 @@ public class AddEditTaskPresenter implements AddEditTaskContract.Presenter,
      * @param addTaskView the add/edit view
      */
     public AddEditTaskPresenter(@Nullable String taskId, @NonNull TasksDataSource tasksRepository,
-            @NonNull AddEditTaskContract.View addTaskView) {
+            @NonNull AddEditTaskContract.View addTaskView, boolean loadData) {
         mTaskId = taskId;
         mTasksRepository = checkNotNull(tasksRepository);
         mAddTaskView = checkNotNull(addTaskView);
+        mLoadData = loadData;
 
         mAddTaskView.setPresenter(this);
     }
 
     @Override
     public void start() {
-        if (!isNewTask()) {
+        if (!isNewTask() && mLoadData) {
             populateTask();
         }
     }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskPresenter.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskPresenter.java
@@ -37,10 +37,10 @@ public class AddEditTaskPresenter implements AddEditTaskContract.Presenter,
     @NonNull
     private final AddEditTaskContract.View mAddTaskView;
 
-    private final boolean mLoadData;
-
     @Nullable
     private String mTaskId;
+
+    private final boolean mLoadData;
 
     /**
      * Creates a presenter for the add/edit view.
@@ -48,6 +48,7 @@ public class AddEditTaskPresenter implements AddEditTaskContract.Presenter,
      * @param taskId ID of the task to edit or null for a new task
      * @param tasksRepository a repository of data for tasks
      * @param addTaskView the add/edit view
+     * @param loadData whether data needs to be loaded or not (like after a rotation)
      */
     public AddEditTaskPresenter(@Nullable String taskId, @NonNull TasksDataSource tasksRepository,
             @NonNull AddEditTaskContract.View addTaskView, boolean loadData) {

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskPresenter.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskPresenter.java
@@ -55,7 +55,7 @@ public class AddEditTaskPresenter implements AddEditTaskContract.Presenter,
         mTaskId = taskId;
         mTasksRepository = checkNotNull(tasksRepository);
         mAddTaskView = checkNotNull(addTaskView);
-        mIsDataMissing = shouldLoadDataFromRepo;q
+        mIsDataMissing = shouldLoadDataFromRepo;
     }
 
     @Override

--- a/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskPresenterTest.java
+++ b/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskPresenterTest.java
@@ -27,6 +27,8 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
@@ -115,11 +117,13 @@ public class AddEditTaskPresenterTest {
 
         // Then the task repository is queried and the view updated
         verify(mTasksRepository).getTask(eq(testTask.getId()), mGetTaskCallbackCaptor.capture());
+        assertThat(mAddEditTaskPresenter.isDataMissing(), is(true));
 
         // Simulate callback
         mGetTaskCallbackCaptor.getValue().onTaskLoaded(testTask);
 
         verify(mAddEditTaskView).setTitle(testTask.getTitle());
         verify(mAddEditTaskView).setDescription(testTask.getDescription());
+        assertThat(mAddEditTaskPresenter.isDataMissing(), is(false));
     }
 }

--- a/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskPresenterTest.java
+++ b/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskPresenterTest.java
@@ -65,7 +65,8 @@ public class AddEditTaskPresenterTest {
     @Test
     public void saveNewTaskToRepository_showsSuccessMessageUi() {
         // Get a reference to the class under test
-        mAddEditTaskPresenter = new AddEditTaskPresenter(null, mTasksRepository, mAddEditTaskView);
+        mAddEditTaskPresenter = new AddEditTaskPresenter(
+                null, mTasksRepository, mAddEditTaskView, true);
 
         // When the presenter is asked to save a task
         mAddEditTaskPresenter.saveTask("New Task Title", "Some Task Description");
@@ -78,7 +79,8 @@ public class AddEditTaskPresenterTest {
     @Test
     public void saveTask_emptyTaskShowsErrorUi() {
         // Get a reference to the class under test
-        mAddEditTaskPresenter = new AddEditTaskPresenter(null, mTasksRepository, mAddEditTaskView);
+        mAddEditTaskPresenter = new AddEditTaskPresenter(
+                null, mTasksRepository, mAddEditTaskView, true);
 
         // When the presenter is asked to save an empty task
         mAddEditTaskPresenter.saveTask("", "");
@@ -90,7 +92,8 @@ public class AddEditTaskPresenterTest {
     @Test
     public void saveExistingTaskToRepository_showsSuccessMessageUi() {
         // Get a reference to the class under test
-        mAddEditTaskPresenter = new AddEditTaskPresenter("1", mTasksRepository, mAddEditTaskView);
+        mAddEditTaskPresenter = new AddEditTaskPresenter(
+                "1", mTasksRepository, mAddEditTaskView, true);
 
         // When the presenter is asked to save an existing task
         mAddEditTaskPresenter.saveTask("Existing Task Title", "Some Task Description");
@@ -105,7 +108,7 @@ public class AddEditTaskPresenterTest {
         Task testTask = new Task("TITLE", "DESCRIPTION");
         // Get a reference to the class under test
         mAddEditTaskPresenter = new AddEditTaskPresenter(testTask.getId(),
-                mTasksRepository, mAddEditTaskView);
+                mTasksRepository, mAddEditTaskView, true);
 
         // When the presenter is asked to populate an existing task
         mAddEditTaskPresenter.populateTask();


### PR DESCRIPTION
Fixing  #217. 

setRetainInstance was not needed, turns out. Not super happy with the `shouldLoadDataFromRepo`. Suggestions?