### PR TITLE
Enables running UI tests from CircleCI on Firebase Test Lab

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,6 +18,6 @@ dependencies:
 
 test:
   override:
-    - echo "y" | sudo /opt/google-cloud-sdk/bin/gcloud beta test android run --app todoapp/app/build/outputs/apk/app-mockDebug.apk --test todoapp/app/build/outputs/apk/app-mockDebug-test-unaligned.apk --results-bucket cloud-test-<PROJECT-ID>
+    - echo "y" | sudo /opt/google-cloud-sdk/bin/gcloud beta test android run --app todoapp/app/build/outputs/apk/app-mockDebug.apk --test todoapp/app/build/outputs/apk/app-mockDebug-test-unaligned.apk --results-bucket cloud-test-android-devrel-ci
   post:
     - sudo /opt/google-cloud-sdk/bin/gsutil -m cp -r -U `sudo /opt/google-cloud-sdk/bin/gsutil ls gs://cloud-test-circle-ctl-test | tail -1` $CIRCLE_ARTIFACTS/ | true

--- a/circle.yml
+++ b/circle.yml
@@ -4,13 +4,20 @@ machine:
 
 dependencies:
   pre:
-    - echo y | android update sdk --no-ui --all --filter "tools,platform-tools,build-tools-24.0.2,android-24,extra-android-m2repository"
+    - sudo pip install -U crcmod
   override:
     - cd todoapp;./gradlew dependencies
   post:
-    - rm -f ~/.gradle/caches/modules-2/modules-2.lock
+    - ./gradlew :app:assembleDebug -PdisablePreDex
+    - ./gradlew :app:assembleDebugTest -PdisablePreDex
+    - echo $GCLOUD_SERVICE_KEY | base64 --decode > ${HOME}/client-secret.json
+    - sudo /opt/google-cloud-sdk/bin/gcloud config set project android-devrel-ci
+    - sudo /opt/google-cloud-sdk/bin/gcloud --quiet components update
+    - sudo /opt/google-cloud-sdk/bin/gcloud --quiet components install beta
+    - sudo /opt/google-cloud-sdk/bin/gcloud auth activate-service-account travis-ci-for-blueprints@android-devrel-ci.iam.gserviceaccount.com --key-file ${HOME}/client-secret.json
 
 test:
   override:
-    - cd todoapp;./gradlew test
-    - cp -r todoapp/app/build/test-results/* $CIRCLE_TEST_REPORTS
+    - echo "y" | sudo /opt/google-cloud-sdk/bin/gcloud beta test android run --app app/build/outputs/apk/app-mockDebug.apk --test app/build/outputs/apk/app-mockDebug-test-unaligned.apk --results-bucket cloud-test-<PROJECT-ID>
+  post:
+    - sudo /opt/google-cloud-sdk/bin/gsutil -m cp -r -U `sudo /opt/google-cloud-sdk/bin/gsutil ls gs://cloud-test-circle-ctl-test | tail -1` $CIRCLE_ARTIFACTS/ | true

--- a/circle.yml
+++ b/circle.yml
@@ -5,11 +5,9 @@ machine:
 dependencies:
   pre:
     - sudo pip install -U crcmod
-  override:
-    - cd todoapp;
   post:
-    - ./gradlew :app:assembleDebug -PdisablePreDex
-    - ./gradlew :app:assembleDebugTest -PdisablePreDex
+    - cd todoapp;./gradlew :app:assembleMockDebug -PdisablePreDex
+    - cd todoapp;./gradlew :app:assembleMockDebugTest -PdisablePreDex
     - echo $GCLOUD_SERVICE_KEY | base64 --decode > ${HOME}/client-secret.json
     - sudo /opt/google-cloud-sdk/bin/gcloud config set project android-devrel-ci
     - sudo /opt/google-cloud-sdk/bin/gcloud --quiet components update
@@ -18,6 +16,6 @@ dependencies:
 
 test:
   override:
-    - echo "y" | sudo /opt/google-cloud-sdk/bin/gcloud beta test android run --app app/build/outputs/apk/app-mockDebug.apk --test app/build/outputs/apk/app-mockDebug-test-unaligned.apk --results-bucket cloud-test-<PROJECT-ID>
+    - echo "y" | sudo /opt/google-cloud-sdk/bin/gcloud beta test android run --app todoapp/app/build/outputs/apk/app-mockDebug.apk --test todoapp/app/build/outputs/apk/app-mockDebug-test-unaligned.apk --results-bucket cloud-test-<PROJECT-ID>
   post:
     - sudo /opt/google-cloud-sdk/bin/gsutil -m cp -r -U `sudo /opt/google-cloud-sdk/bin/gsutil ls gs://cloud-test-circle-ctl-test | tail -1` $CIRCLE_ARTIFACTS/ | true

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ dependencies:
   pre:
     - sudo pip install -U crcmod
   override:
-    - cd todoapp;./gradlew dependencies
+    - cd todoapp;
   post:
     - ./gradlew :app:assembleDebug -PdisablePreDex
     - ./gradlew :app:assembleDebugTest -PdisablePreDex

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,8 @@ machine:
 dependencies:
   pre:
     - sudo pip install -U crcmod
+    - echo y | android update sdk --no-ui --all --filter "tools,platform-tools,build-tools-24.0.2,android-24,extra-android-m2repository"
+
   post:
     - cd todoapp;./gradlew :app:assembleMockDebug -PdisablePreDex
     - cd todoapp;./gradlew :app:assembleMockDebugTest -PdisablePreDex

--- a/circle.yml
+++ b/circle.yml
@@ -18,6 +18,6 @@ dependencies:
 
 test:
   override:
-    - echo "y" | sudo /opt/google-cloud-sdk/bin/gcloud beta test android run --app todoapp/app/build/outputs/apk/app-mockDebug.apk --test todoapp/app/build/outputs/apk/app-mockDebug-test-unaligned.apk --results-bucket cloud-test-android-devrel-ci
+    - echo "y" | sudo /opt/google-cloud-sdk/bin/gcloud beta test android run --app todoapp/app/build/outputs/apk/app-mock-debug.apk --test todoapp/app/build/outputs/apk/app-mock-debug-androidTest.apk -d Nexus5X,Nexus10 -v 22 -l fr --results-bucket cloud-test-android-devrel-ci
   post:
-    - sudo /opt/google-cloud-sdk/bin/gsutil -m cp -r -U `sudo /opt/google-cloud-sdk/bin/gsutil ls gs://cloud-test-circle-ctl-test | tail -1` $CIRCLE_ARTIFACTS/ | true
+    - sudo /opt/google-cloud-sdk/bin/gsutil -m cp -r -U `sudo /opt/google-cloud-sdk/bin/gsutil ls gs://cloud-test-android-devrel-ci | tail -1` $CIRCLE_ARTIFACTS/ | true

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ dependencies:
   post:
     - cd todoapp;./gradlew :app:assembleDebug -PdisablePreDex
     - cd todoapp;./gradlew :app:assembleAndroidTest -PdisablePreDex
-    - echo $GCLOUD_SERVICE_KEY | base64 --decode > ${HOME}/client-secret.json
+    - echo ${GCLOUD_SERVICE_KEY} | base64 --decode > ${HOME}/client-secret.json
     - sudo /opt/google-cloud-sdk/bin/gcloud config set project android-devrel-ci
     - sudo /opt/google-cloud-sdk/bin/gcloud --quiet components update
     - sudo /opt/google-cloud-sdk/bin/gcloud --quiet components install beta

--- a/circle.yml
+++ b/circle.yml
@@ -8,8 +8,8 @@ dependencies:
     - echo y | android update sdk --no-ui --all --filter "tools,platform-tools,build-tools-24.0.2,android-24,extra-android-m2repository"
 
   post:
-    - cd todoapp;./gradlew :app:assembleMockDebug -PdisablePreDex
-    - cd todoapp;./gradlew :app:assembleMockDebugTest -PdisablePreDex
+    - cd todoapp;./gradlew :app:assembleDebug -PdisablePreDex
+    - cd todoapp;./gradlew :app:assembleAndroidTest -PdisablePreDex
     - echo $GCLOUD_SERVICE_KEY | base64 --decode > ${HOME}/client-secret.json
     - sudo /opt/google-cloud-sdk/bin/gcloud config set project android-devrel-ci
     - sudo /opt/google-cloud-sdk/bin/gcloud --quiet components update


### PR DESCRIPTION
For the record: I tried 4 o 5 different ways of decoding the gcloud key. Turns out the base64 string in the env variable must have no spaces. SSHing into the container is neat.

Runs on Nexus10 api 21 and Nexus5X api 25 emulators. 

TODO: 
 - Would devices be faster? 
 - Compatibility check every 24h with real devices from different OEMs?

ping #229 