### PR TITLE
[Todo-MVP] Statistics Activity back button exits app

### DIFF
--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksActivity.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksActivity.java
@@ -113,8 +113,6 @@ public class TasksActivity extends AppCompatActivity {
                             case R.id.statistics_navigation_menu_item:
                                 Intent intent =
                                         new Intent(TasksActivity.this, StatisticsActivity.class);
-                                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK
-                                        | Intent.FLAG_ACTIVITY_CLEAR_TASK);
                                 startActivity(intent);
                                 break;
                             default:


### PR DESCRIPTION
When the user clicks on the navigation drawer from the Tasks activity and navigates to the Statistics activity the backstack is erased.  When the user clicks on the back button on the Statistics page it exits the app instead of taking back to the Tasks page.  Deleting these two intent flags fixes this behavior.