### PR TITLE
[dev-todo-mvvm-live] Removed unnecessary parameters from the `saveTask` method 

### DIFF
--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.java
@@ -108,7 +108,7 @@ public class AddEditTaskFragment extends LifecycleFragment {
         fab.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                mViewModel.saveTask(mViewModel.title.get(), mViewModel.description.get());
+                mViewModel.saveTask();
             }
         });
     }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.java
@@ -105,8 +105,8 @@ public class AddEditTaskViewModel extends AndroidViewModel implements TasksDataS
     }
 
     // Called when clicking on fab.
-    void saveTask(String title, String description) {
-        Task task = new Task(title, description);
+    void saveTask() {
+        Task task = new Task(title.get(), description.get());
         if (task.isEmpty()) {
             mSnackbarText.setValue(R.string.empty_task_message);
             return;
@@ -114,7 +114,7 @@ public class AddEditTaskViewModel extends AndroidViewModel implements TasksDataS
         if (isNewTask() || mTaskId == null) {
             createTask(task);
         } else {
-            task = new Task(title, description, mTaskId, mTaskCompleted);
+            task = new Task(title.get(), description.get(), mTaskId, mTaskCompleted);
             updateTask(task);
         }
     }

--- a/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModelTest.java
+++ b/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModelTest.java
@@ -74,7 +74,9 @@ public class AddEditTaskViewModelTest {
     @Test
     public void saveNewTaskToRepository_showsSuccessMessageUi() {
         // When the ViewModel is asked to save a task
-        mAddEditTaskViewModel.saveTask("New Task Title", "Some Task Description");
+        mAddEditTaskViewModel.description.set("Some Task Description");
+        mAddEditTaskViewModel.title.set("New Task Title");
+        mAddEditTaskViewModel.saveTask();
 
         // Then a task is saved in the repository and the view updated
         verify(mTasksRepository).saveTask(any(Task.class)); // saved to the model


### PR DESCRIPTION
The `AddEditTaskViewModel` already contains the title and description of
the task. In order to be a more accurate example of MVVM and the flow of information, the title and description is now
just obtained from the variables in `AddEditTaskViewModel` itself instead of being passed through
from the Fragment.