### PR TITLE
[todo-mvvm-databinding] Removed unnecessary parameters from the `saveTask` method

### DIFF
--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.java
@@ -122,7 +122,7 @@ public class AddEditTaskFragment extends Fragment {
         fab.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                mViewModel.saveTask(mViewModel.title.get(), mViewModel.description.get());
+                mViewModel.saveTask();
             }
         });
     }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.java
@@ -108,11 +108,11 @@ public class AddEditTaskViewModel implements TasksDataSource.GetTaskCallback {
     }
 
     // Called when clicking on fab.
-    public void saveTask(String title, String description) {
+    public void saveTask() {
         if (isNewTask()) {
-            createTask(title, description);
+            createTask(title.get(), description.get());
         } else {
-            updateTask(title, description);
+            updateTask(title.get(), description.get());
         }
     }
 

--- a/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModelTest.java
+++ b/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModelTest.java
@@ -71,7 +71,9 @@ public class AddEditTaskViewModelTest {
     @Test
     public void saveNewTaskToRepository_showsSuccessMessageUi() {
         // When the ViewModel is asked to save a task
-        mAddEditTaskViewModel.saveTask("New Task Title", "Some Task Description");
+        mAddEditTaskViewModel.description.set("Some Task Description");
+        mAddEditTaskViewModel.title.set("New Task Title");
+        mAddEditTaskViewModel.saveTask();
 
         // Then a task is saved in the repository and the view updated
         verify(mTasksRepository).saveTask(any(Task.class)); // saved to the model


### PR DESCRIPTION
As a more complete example usage of MVVM, I've changed the `saveTask()` method to not take any parameters into the method as the `ViewModel` already has the title and description as class variables. 
Now I am using the values from ViewModel itself instead of passing the values back through to the ViewModel from the Fragment.