### PR TITLE
Change scheduler from computation to io

### DIFF
--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksPresenter.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksPresenter.java
@@ -131,7 +131,7 @@ public class TasksPresenter implements TasksContract.Presenter {
                     }
                 })
                 .toList()
-                .subscribeOn(mSchedulerProvider.computation())
+                .subscribeOn(mSchedulerProvider.io())
                 .observeOn(mSchedulerProvider.ui())
                 .doOnTerminate(() -> {
                     if (!EspressoIdlingResource.getIdlingResource().isIdleNow()) {


### PR DESCRIPTION
Currently the scheduler used for getting tasks is `computation`.  The `io` scheduler is better to use in any operation that is reading from disk or network.  The reasoning is due to computation being a bounded thread pool. With a bounded thread pool you run the possibility of various network operations  blocking all computation threads.  If we use the computation scheduler for network/disk reads that take a long time we may not have a computation thread available when we truly need a thread for in memory background processing. `io` is a scheduler that is not bounded leaving the few computation threads still available.

