### PR TITLE
[todo-mvp-dagger] Removed unnecessary injection call

### DIFF
--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/ToDoApplication.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/ToDoApplication.java
@@ -23,9 +23,7 @@ public class ToDoApplication extends DaggerApplication {
 
     @Override
     protected AndroidInjector<? extends DaggerApplication> applicationInjector() {
-        AppComponent appComponent = DaggerAppComponent.builder().application(this).build();
-        appComponent.inject(this);
-        return appComponent;
+        return DaggerAppComponent.builder().application(this).build();
     }
 
     /**

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/ToDoApplication.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/ToDoApplication.java
@@ -2,15 +2,11 @@ package com.example.android.architecture.blueprints.todoapp;
 
 import android.app.Application;
 import android.support.annotation.VisibleForTesting;
-
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepository;
-import com.example.android.architecture.blueprints.todoapp.di.AppComponent;
 import com.example.android.architecture.blueprints.todoapp.di.DaggerAppComponent;
-
-import javax.inject.Inject;
-
 import dagger.android.AndroidInjector;
 import dagger.android.DaggerApplication;
+import javax.inject.Inject;
 
 /**
  * We create a custom {@link Application} class that extends  {@link DaggerApplication}.

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/di/AppComponent.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/di/AppComponent.java
@@ -1,18 +1,14 @@
 package com.example.android.architecture.blueprints.todoapp.di;
 
 import android.app.Application;
-
 import com.example.android.architecture.blueprints.todoapp.ToDoApplication;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepository;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepositoryModule;
-
-import javax.inject.Singleton;
-
 import dagger.BindsInstance;
 import dagger.Component;
 import dagger.android.AndroidInjector;
-import dagger.android.DaggerApplication;
 import dagger.android.support.AndroidSupportInjectionModule;
+import javax.inject.Singleton;
 
 /**
  * This is a Dagger component. Refer to {@link ToDoApplication} for the list of Dagger components
@@ -30,15 +26,9 @@ import dagger.android.support.AndroidSupportInjectionModule;
         ApplicationModule.class,
         ActivityBindingModule.class,
         AndroidSupportInjectionModule.class})
-
-public interface AppComponent extends AndroidInjector<DaggerApplication> {
-
-    void inject(ToDoApplication application);
+public interface AppComponent extends AndroidInjector<ToDoApplication> {
 
     TasksRepository getTasksRepository();
-
-    @Override
-    void inject(DaggerApplication instance);
 
     // Gives us syntactic sugar. we can then do DaggerAppComponent.builder().application(this).build().inject(this);
     // never having to instantiate any modules or say which module we are passing the application to.


### PR DESCRIPTION
closes #432 

`ToDoApplication` does not need to be injected when `applicationInjector()` gets called.

See https://github.com/google/dagger/blob/e8d7cd4c29c1316c5bb1cf0737d4f29111fcb1c8/java/dagger/android/DaggerApplication.java#L56-L61
> Implementations should return an AndroidInjector for the concrete DaggerApplication

The injection is handled in the parent [`dagger.android.DaggerApplication#onCreate`](https://github.com/google/dagger/blob/master/java/dagger/android/DaggerApplication.java#L53)