### PR TITLE
A fix for the memory leak issue

### DIFF
--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/AbstractBasePresenter.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/AbstractBasePresenter.java
@@ -1,0 +1,107 @@
+package com.example.android.architecture.blueprints.todoapp;
+
+/**
+ * This is the parent of all presenters in this project; it also provides the most
+ * fundamental implementation of {@link BasePresenter}. The main purpose of this class
+ * is it to prevent leaking memory whenever we execute use cases.
+ *
+ * A memory leak will occur if we execute a long-running use case, that references the
+ * presenter's view in the callback of the use case (anonymous inner-class), and the
+ * implementation of the view (Activity/Fragment/View)'s lifecycle has ended before the
+ * completion of the use case.
+ *
+ * We could experiment with various usages of {@link java.lang.ref.WeakReference}
+ * to hold references to the views, but all the ways I've tried worked to no avail.
+ *
+ * The best way that I have found to prevent the above mentioned memory leak from by
+ * manually removing the reference to the presenter's view in the appropriate Android
+ * framework lifecycle callback. This is why I have added the {@link #attach(BaseView)}
+ * and {@link #detach()} methods to {@link BasePresenter}. We'll attach the view to the
+ * presenter whenever appropriate and then detach the view whenever appropriate as well
+ * for each presenter we'll create.
+ *
+ * Please note that doing the above solution (attach/detach the presenter's view) implicates
+ * a {@link NullPointerException} whenever the use case's callback attempts to call a method
+ * on the presenter's view that has been detached. As a solution to this problem there's two
+ * ways I've found to fix this:
+ *
+ * (1) Wrapping the use case's callback in a nested inner-class that checks if the presenter's
+ * view is null before invoking the wrapped callback's methods, and
+ *
+ * (2) Setting up a visitor pattern in the use case scheduler and creating an implementation
+ * of it in this presenter to visit if the view is null before invoking the use case callback's
+ * methods.
+ *
+ * This example uses the first solutions.
+ *
+ *
+ * @author Tyler Suehr
+ * @version 1.0
+ */
+public abstract class AbstractBasePresenter<IView extends BaseView> implements BasePresenter<IView> {
+    /* Stores reference to the presenter's use case handler */
+    private final UseCaseHandler mUseCaseHandler;
+    /* Stores reference to the presenter's view */
+    protected IView mView;
+
+
+    public AbstractBasePresenter(final UseCaseHandler handler) {
+        this.mUseCaseHandler = handler;
+    }
+
+    public AbstractBasePresenter(final IView view, final UseCaseHandler handler) {
+        this.mView = view;
+        this.mUseCaseHandler = handler;
+    }
+
+    @Override
+    public void attach(IView view) {
+        this.mView = view;
+    }
+
+    @Override
+    public void detach() {
+        this.mView = null;
+    }
+
+    /**
+     * This will schedule the execution of a use case with {@link #mUseCaseHandler}.
+     *
+     * The main purpose of this method is to wrap the given callback in another implementation
+     * that will ensure the presenter's view isn't null when invoking the wrapped callback's
+     * methods.
+     *
+     * @param useCase {@link UseCase}
+     * @param request Request data
+     * @param callback {@link UseCase.UseCaseCallback}
+     * @param <T> Request data type
+     * @param <V> Response data type
+     */
+    protected <T extends UseCase.RequestValues,V extends UseCase.ResponseValue> void
+    schedule(final UseCase<T,V> useCase, final T request, final UseCase.UseCaseCallback<V> callback) {
+        this.mUseCaseHandler.execute(useCase, request, new NullCheckWrapper<>(callback));
+    }
+
+
+    /**
+     * Nested inner-class that will wrap a given use case callback and will ensure that the
+     * presenter's view is not null before invoking the wrapped callback's methods.
+     */
+    private final class NullCheckWrapper<V extends UseCase.ResponseValue> implements UseCase.UseCaseCallback<V> {
+        private final UseCase.UseCaseCallback<V> mWrap;
+
+        NullCheckWrapper(final UseCase.UseCaseCallback<V> wrap) {
+            this.mWrap = wrap;
+        }
+
+        @Override
+        public void onSuccess(V response) {
+            if (mView != null) { this.mWrap.onSuccess(response); }
+        }
+
+        @Override
+        public void onError() {
+            if (mView != null) { this.mWrap.onError(); }
+        }
+    }
+}

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/BasePresenter.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/BasePresenter.java
@@ -16,8 +16,24 @@
 
 package com.example.android.architecture.blueprints.todoapp;
 
-public interface BasePresenter {
-
+/**
+ * We'll use generics here too for the view's type.
+ */
+public interface BasePresenter<IView extends BaseView> {
     void start();
 
+    /**
+     * Attaches a view to this presenter.
+     * @param view {@link IView}
+     */
+    void attach(IView view);
+
+    /**
+     * Detaches the view from this presenter... this is the core solution
+     * for the memory leak issue.
+     *
+     * We need to ensure we remove the reference of the view (Activity/Fragment/View)
+     * from the presenter whenever the Android component's life ends.
+     */
+    void detach();
 }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/UseCaseHandler.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/UseCaseHandler.java
@@ -36,7 +36,7 @@ public class UseCaseHandler {
     public <T extends UseCase.RequestValues, R extends UseCase.ResponseValue> void execute(
             final UseCase<T, R> useCase, T values, UseCase.UseCaseCallback<R> callback) {
         useCase.setRequestValues(values);
-        useCase.setUseCaseCallback(new UiCallbackWrapper(callback, this));
+        useCase.setUseCaseCallback(new UiCallbackWrapper<>(callback, this));
         final WeakReference<UseCase<T, R>> weakUseCase = new WeakReference<>(useCase);
 
         // The network request might be handled in a different thread so make sure

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/UseCaseScheduler.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/UseCaseScheduler.java
@@ -23,6 +23,12 @@ public interface UseCaseScheduler {
 
     void execute(Runnable runnable);
 
+    /**
+     * Attempts to shutdown all active executions and will cancel any
+     * pending executions.
+     */
+    void shutdownExecution();
+
     <V extends UseCase.ResponseValue> void notifyResponse(final V response,
             final UseCase.UseCaseCallback<V> useCaseCallback);
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/UseCaseThreadPoolScheduler.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/UseCaseThreadPoolScheduler.java
@@ -30,13 +30,16 @@ import java.util.concurrent.TimeUnit;
  * {@link java.util.concurrent.ExecutorService}s for different scenarios.
  */
 public class UseCaseThreadPoolScheduler implements UseCaseScheduler {
+    /* Constants for thread-pool */
+    private static final int POOL_SIZE     = 2;
+    private static final int MAX_POOL_SIZE = 4;
+    private static final int TIMEOUT      = 30;
+
+    /* Stores reference to handler for UI-Thread */
     private final Handler mHandler = new Handler();
 
-    public static final int POOL_SIZE = 2;
-    public static final int MAX_POOL_SIZE = 4;
-    public static final int TIMEOUT = 30;
-
-    static ThreadPoolExecutor mThreadPoolExecutor;
+    /* Stores reference to thread-pool executor */
+    private static ThreadPoolExecutor mThreadPoolExecutor;
 
 
     @Override
@@ -85,7 +88,7 @@ public class UseCaseThreadPoolScheduler implements UseCaseScheduler {
      *
      * @return {@link ThreadPoolExecutor}
      */
-    static synchronized ThreadPoolExecutor getExecutor() {
+    private static synchronized ThreadPoolExecutor getExecutor() {
         if (mThreadPoolExecutor == null) {
             mThreadPoolExecutor = new ThreadPoolExecutor(POOL_SIZE, MAX_POOL_SIZE, TIMEOUT,
                     TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(POOL_SIZE));

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskContract.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskContract.java
@@ -18,6 +18,7 @@ package com.example.android.architecture.blueprints.todoapp.addedittask;
 
 import com.example.android.architecture.blueprints.todoapp.BasePresenter;
 import com.example.android.architecture.blueprints.todoapp.BaseView;
+import com.example.android.architecture.blueprints.todoapp.statistics.StatisticsContract;
 
 /**
  * This specifies the contract between the view and the presenter.
@@ -37,7 +38,7 @@ public interface AddEditTaskContract {
         boolean isActive();
     }
 
-    interface Presenter extends BasePresenter {
+    interface Presenter extends BasePresenter<AddEditTaskContract.View> {
 
         void saveTask(String title, String description);
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.java
@@ -60,6 +60,12 @@ public class AddEditTaskFragment extends Fragment implements AddEditTaskContract
     }
 
     @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        mPresenter.detach();
+    }
+
+    @Override
     public void setPresenter(@NonNull AddEditTaskContract.Presenter presenter) {
         mPresenter = checkNotNull(presenter);
     }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsContract.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsContract.java
@@ -35,7 +35,7 @@ public interface StatisticsContract {
         boolean isActive();
     }
 
-    interface Presenter extends BasePresenter {
+    interface Presenter extends BasePresenter<View> {
 
     }
 }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsFragment.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsFragment.java
@@ -63,6 +63,12 @@ public class StatisticsFragment extends Fragment implements StatisticsContract.V
     }
 
     @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        mPresenter.detach();
+    }
+
+    @Override
     public void setProgressIndicator(boolean active) {
         if (active) {
             mStatisticsTV.setText(getString(R.string.loading));

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsPresenter.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsPresenter.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import android.support.annotation.NonNull;
 
+import com.example.android.architecture.blueprints.todoapp.AbstractBasePresenter;
 import com.example.android.architecture.blueprints.todoapp.UseCase;
 import com.example.android.architecture.blueprints.todoapp.UseCaseHandler;
 import com.example.android.architecture.blueprints.todoapp.statistics.domain.usecase.GetStatistics;
@@ -29,21 +30,21 @@ import com.example.android.architecture.blueprints.todoapp.statistics.domain.mod
  * Listens to user actions from the UI ({@link StatisticsFragment}), retrieves the data and updates
  * the UI as required.
  */
-public class StatisticsPresenter implements StatisticsContract.Presenter {
-
-    private final StatisticsContract.View mStatisticsView;
-    private final UseCaseHandler mUseCaseHandler;
+public class StatisticsPresenter
+        extends AbstractBasePresenter<StatisticsContract.View>
+        implements StatisticsContract.Presenter {
     private final GetStatistics mGetStatistics;
+
 
     public StatisticsPresenter(
             @NonNull UseCaseHandler useCaseHandler,
             @NonNull StatisticsContract.View statisticsView,
             @NonNull GetStatistics getStatistics) {
-        mUseCaseHandler = checkNotNull(useCaseHandler, "useCaseHandler cannot be null!");
-        mStatisticsView = checkNotNull(statisticsView, "StatisticsView cannot be null!");
+        super(statisticsView, useCaseHandler);
+
         mGetStatistics = checkNotNull(getStatistics,"getStatistics cannot be null!");
 
-        mStatisticsView.setPresenter(this);
+        mView.setPresenter(this);
     }
 
     @Override
@@ -52,29 +53,29 @@ public class StatisticsPresenter implements StatisticsContract.Presenter {
     }
 
     private void loadStatistics() {
-        mStatisticsView.setProgressIndicator(true);
+        mView.setProgressIndicator(true);
 
-        mUseCaseHandler.execute(mGetStatistics, new GetStatistics.RequestValues(),
+        schedule(mGetStatistics, new GetStatistics.RequestValues(),
                 new UseCase.UseCaseCallback<GetStatistics.ResponseValue>() {
             @Override
             public void onSuccess(GetStatistics.ResponseValue response) {
                 Statistics statistics = response.getStatistics();
                 // The view may not be able to handle UI updates anymore
-                if (!mStatisticsView.isActive()) {
+                if (!mView.isActive()) {
                     return;
                 }
-                mStatisticsView.setProgressIndicator(false);
+                mView.setProgressIndicator(false);
 
-                mStatisticsView.showStatistics(statistics.getActiveTasks(), statistics.getCompletedTasks());
+                mView.showStatistics(statistics.getActiveTasks(), statistics.getCompletedTasks());
             }
 
             @Override
             public void onError() {
                 // The view may not be able to handle UI updates anymore
-                if (!mStatisticsView.isActive()) {
+                if (!mView.isActive()) {
                     return;
                 }
-                mStatisticsView.showLoadingStatisticsError();
+                mView.showLoadingStatisticsError();
             }
         });
     }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailContract.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailContract.java
@@ -51,7 +51,7 @@ public interface TaskDetailContract {
         boolean isActive();
     }
 
-    interface Presenter extends BasePresenter {
+    interface Presenter extends BasePresenter<View> {
 
         void editTask();
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.java
@@ -74,6 +74,12 @@ public class TaskDetailFragment extends Fragment implements TaskDetailContract.V
         mPresenter.start();
     }
 
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        mPresenter.detach();
+    }
+
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksContract.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksContract.java
@@ -66,7 +66,7 @@ public interface TasksContract {
         void showFilteringPopUpMenu();
     }
 
-    interface Presenter extends BasePresenter {
+    interface Presenter extends BasePresenter<View> {
 
         void result(int requestCode, int resultCode);
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.java
@@ -85,6 +85,12 @@ public class TasksFragment extends Fragment implements TasksContract.View {
     }
 
     @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        mPresenter.detach();
+    }
+
+    @Override
     public void onResume() {
         super.onResume();
         mPresenter.start();

--- a/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/TestUseCaseScheduler.java
+++ b/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/TestUseCaseScheduler.java
@@ -26,6 +26,11 @@ public class TestUseCaseScheduler implements UseCaseScheduler {
     }
 
     @Override
+    public void shutdownExecution() {
+        // No implementation
+    }
+
+    @Override
     public <R extends UseCase.ResponseValue> void notifyResponse(R response,
             UseCase.UseCaseCallback<R> useCaseCallback) {
         useCaseCallback.onSuccess(response);


### PR DESCRIPTION
The main purpose of this pull request is it to prevent leaking memory whenever we execute use cases.

A memory leak will occur if we execute a long-running use case, that references the presenter's view in the callback of the use case (anonymous inner-class), and the implementation of the view (Activity/Fragment/View)'s lifecycle has ended before the completion of the use case.

The best way that I have found to prevent the above mentioned memory leak is by manually removing the reference to the presenter's view in the appropriate Android framework lifecycle callback for each implementation of the view.