### PR TITLE
add cache class to separate caching logic from TasksRepository Fixes #522

### DIFF
--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.java
@@ -87,8 +87,8 @@ public class TasksRepository implements TasksDataSource {
     public void getTasks(@NonNull final LoadTasksCallback callback) {
         checkNotNull(callback);
 
-        // Respond immediately with cache if available and not dirty
-        if (!mTasksCache.isDirty()) {
+        // Respond immediately with cache if not empty and not dirty
+        if (!mTasksCache.isEmpty() && !mTasksCache.isDirty()) {
             callback.onTasksLoaded(mTasksCache.getTasks());
             return;
         }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/cache/TasksCache.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/cache/TasksCache.java
@@ -30,12 +30,17 @@ public class TasksCache {
         return mDirty;
     }
 
+    public boolean isEmpty() {
+        if (mCache == null) mCache = new LinkedHashMap<>();
+        return mCache.isEmpty();
+    }
+
     public Task getTask(String taskId) {
         if (mCache == null) return null;
         return mCache.get(taskId);
     }
 
-    public ArrayList<Task> getTasks() {
+    public List<Task> getTasks() {
         if (mCache == null) return new ArrayList<>();
         return new ArrayList<>(mCache.values());
     }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/cache/TasksCache.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/cache/TasksCache.java
@@ -1,0 +1,82 @@
+package com.example.android.architecture.blueprints.todoapp.data.source.cache;
+
+import com.example.android.architecture.blueprints.todoapp.data.Task;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TasksCache {
+
+    private static TasksCache INSTANCE;
+
+    private Map<String, Task> mCache;
+
+    private boolean mDirty = false;
+
+    public static TasksCache getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new TasksCache();
+        }
+        return INSTANCE;
+    }
+
+    // Prevent direct instantiation.
+    private TasksCache() {}
+
+    public boolean isDirty() {
+        return mDirty;
+    }
+
+    public Task getTask(String taskId) {
+        if (mCache == null) return null;
+        return mCache.get(taskId);
+    }
+
+    public ArrayList<Task> getTasks() {
+        if (mCache == null) return new ArrayList<>();
+        return new ArrayList<>(mCache.values());
+    }
+
+    public void saveTask(Task task) {
+        if (mCache == null) mCache = new LinkedHashMap<>();
+        mCache.put(task.getId(), task);
+    }
+
+    public void deleteTask(String taskId) {
+        if (mCache == null) mCache = new LinkedHashMap<>();
+        mCache.remove(taskId);
+    }
+
+    public void deleteAllTasks() {
+        if (mCache == null) mCache = new LinkedHashMap<>();
+        mCache.clear();
+    }
+
+    public void clearCompletedTasks() {
+        if (mCache == null) mCache = new LinkedHashMap<>();
+        Iterator<Map.Entry<String, Task>> it = mCache.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<String, Task> entry = it.next();
+            if (entry.getValue().isCompleted()) {
+                it.remove();
+            }
+        }
+    }
+
+    public void invalidate() {
+        mDirty = true;
+    }
+
+    public void refresh(List<Task> tasks) {
+        if (mCache == null) mCache = new LinkedHashMap<>();
+        mCache.clear();
+        for (Task task : tasks) {
+            mCache.put(task.getId(), task);
+        }
+        mDirty = false;
+    }
+
+}

--- a/todoapp/app/src/mock/java/com/example/android/architecture/blueprints/todoapp/Injection.java
+++ b/todoapp/app/src/mock/java/com/example/android/architecture/blueprints/todoapp/Injection.java
@@ -22,6 +22,7 @@ import android.support.annotation.NonNull;
 import com.example.android.architecture.blueprints.todoapp.data.FakeTasksRemoteDataSource;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksDataSource;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepository;
+import com.example.android.architecture.blueprints.todoapp.data.source.cache.TasksCache;
 import com.example.android.architecture.blueprints.todoapp.data.source.local.ToDoDatabase;
 import com.example.android.architecture.blueprints.todoapp.data.source.local.TasksLocalDataSource;
 import com.example.android.architecture.blueprints.todoapp.util.AppExecutors;
@@ -39,7 +40,7 @@ public class Injection {
         checkNotNull(context);
         ToDoDatabase database = ToDoDatabase.getInstance(context);
         return TasksRepository.getInstance(FakeTasksRemoteDataSource.getInstance(),
-                TasksLocalDataSource.getInstance(new AppExecutors(),
-                        database.taskDao()));
+                TasksLocalDataSource.getInstance(new AppExecutors(), database.taskDao()),
+                TasksCache.getInstance());
     }
 }

--- a/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/data/source/cache/TasksCacheTest.java
+++ b/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/data/source/cache/TasksCacheTest.java
@@ -1,0 +1,149 @@
+package com.example.android.architecture.blueprints.todoapp.data.source.cache;
+
+import com.example.android.architecture.blueprints.todoapp.data.Task;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class TasksCacheTest {
+
+    private final static String TASK_TITLE = "title";
+
+    private TasksCache mTasksCache;
+
+    @Before
+    public void setUp() {
+        mTasksCache = TasksCache.getInstance();
+    }
+
+    @After
+    public void tearDown() {
+        mTasksCache.refresh(new ArrayList<Task>());
+    }
+
+    @Test
+    public void isNotDirty_initially() throws Exception {
+        assertFalse(mTasksCache.isDirty());
+    }
+
+    @Test
+    public void isEmpty_initially() throws Exception {
+        assertEquals(mTasksCache.isEmpty(), true);
+    }
+
+    @Test
+    public void isNotEmpty_afterAddingTasks() throws Exception {
+        Task task = new Task(TASK_TITLE, "Some Task Description");
+
+        mTasksCache.saveTask(task);
+
+        assertFalse(mTasksCache.isEmpty());
+    }
+
+    @Test
+    public void getTask_returnsTaskSpecified() throws Exception {
+        Task task = new Task(TASK_TITLE, "Some Task Description");
+
+        mTasksCache.saveTask(task);
+
+        assertEquals(mTasksCache.getTask(task.getId()).getId(), task.getId());
+    }
+
+    @Test
+    public void getTask_returnsNullForUnsavedTaskId() throws Exception {
+        Task task = new Task(TASK_TITLE, "Some Task Description");
+
+        mTasksCache.saveTask(task);
+
+        assertNull(mTasksCache.getTask(task.getId() + "a"));
+    }
+
+    @Test
+    public void getTasks_returnsAllTasks() throws Exception {
+        Task task1 = new Task(TASK_TITLE, "Some Task Description");
+        Task task2 = new Task(TASK_TITLE, "Some Task Description");
+
+        mTasksCache.saveTask(task1);
+        mTasksCache.saveTask(task2);
+
+        List<Task> tasks = mTasksCache.getTasks();
+        assertEquals(tasks.size(), 2);
+    }
+
+    @Test
+    public void deleteTask_deletesTaskSpecified() throws Exception {
+        Task task = new Task(TASK_TITLE, "Some Task Description");
+
+        mTasksCache.saveTask(task);
+        mTasksCache.deleteTask(task.getId());
+
+        assertNull(mTasksCache.getTask(task.getId()));
+    }
+
+    @Test
+    public void deleteTask_doesNotCrashWithIncorrectId() throws Exception {
+        Task task = new Task(TASK_TITLE, "Some Task Description");
+
+        mTasksCache.saveTask(task);
+        mTasksCache.deleteTask(task.getId() + "a");
+    }
+
+    @Test
+    public void deleteAllTasks_deletesAllTasks() throws Exception {
+        Task task1 = new Task(TASK_TITLE, "Some Task Description");
+        Task task2 = new Task(TASK_TITLE, "Some Task Description");
+
+        mTasksCache.saveTask(task1);
+        mTasksCache.saveTask(task2);
+        mTasksCache.deleteAllTasks();
+
+        List<Task> tasks = mTasksCache.getTasks();
+        assertEquals(tasks.size(), 0);
+    }
+
+    @Test
+    public void clearCompletedTasks_clearsCompletedTasksOnly() throws Exception {
+        Task task1 = new Task(TASK_TITLE, "Some Task Description", true);
+        Task task2 = new Task(TASK_TITLE, "Some Task Description");
+
+        mTasksCache.saveTask(task1);
+        mTasksCache.saveTask(task2);
+        mTasksCache.clearCompletedTasks();
+
+        List<Task> tasks = mTasksCache.getTasks();
+        assertEquals(tasks.size(), 1);
+        assertEquals(task2.getId(), tasks.get(0).getId());
+    }
+
+    @Test
+    public void invalidate_makesCacheDirty() throws Exception {
+        mTasksCache.invalidate();
+        assertTrue(mTasksCache.isDirty());
+    }
+
+    @Test
+    public void refresh_deletesAllTasksAndMakesCacheClean() throws Exception {
+        Task task1 = new Task(TASK_TITLE, "Some Task Description");
+        Task task2 = new Task(TASK_TITLE, "Some Task Description");
+        Task task3 = new Task(TASK_TITLE, "Some Task Description");
+
+        mTasksCache.saveTask(task1);
+        mTasksCache.saveTask(task2);
+
+        List<Task> tasks = new ArrayList<>();
+        tasks.add(task3);
+        mTasksCache.refresh(tasks);
+
+        tasks = mTasksCache.getTasks();
+        assertFalse(mTasksCache.isDirty());
+        assertEquals(tasks.size(), 1);
+        assertEquals(task3.getId(), tasks.get(0).getId());
+    }
+
+}


### PR DESCRIPTION
This commit adds a new class that handles Task caching. This change
pulls the logic for caching out of the TasksRepository to more closely
adhere to the Single Responsibility Principle (SRP). Now the repository
need not worry about null cache objects, iterating through the cache, or
keeping track of whether the cache is dirty or not.