### PR TITLE
Fix "Failed to Resolve: runtime"

### DIFF
--- a/todoapp/build.gradle
+++ b/todoapp/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0'
@@ -13,8 +13,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }
 


### PR DESCRIPTION
As mentioned in: https://stackoverflow.com/a/50758769/5864033

>yes ,
If you are getting error like error run time you can change the position of google() in dependencies in build. gradle.. Like below:

`repositories { 
google()
 jcenter()
}`