### PR TITLE
Update SingleLiveEvent.java

### DIFF
--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/SingleLiveEvent.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/SingleLiveEvent.java
@@ -42,7 +42,7 @@ public class SingleLiveEvent<T> extends MutableLiveData<T> {
     private final AtomicBoolean mPending = new AtomicBoolean(false);
 
     @MainThread
-    public void observe(LifecycleOwner owner, final Observer<T> observer) {
+    public void observe(@NonNull LifecycleOwner owner, @NonNull final Observer<? super T> observer) {
 
         if (hasActiveObservers()) {
             Log.w(TAG, "Multiple observers registered but only one will be notified of changes.");


### PR DESCRIPTION
Adding `Observer<? super T>` will prevent: 

> "observe(LifecycleOwner, Observer<T>) in ...SingleLiveEvent.class clashes with observe(LifecycleOwner, Observer<? super T>) in androidx.lifecycle.LiveData; both methods have same erasure, yet neither overrides the other."