### PR TITLE
Switched the order of dependencies to fix missing manifest merger

### DIFF
--- a/todoapp/build.gradle
+++ b/todoapp/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0'
@@ -13,8 +13,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }
 


### PR DESCRIPTION
More info: https://stackoverflow.com/questions/50563783/could-not-find-manifest-merger-jar-com-android-tools-buildmanifest-merger26-1