### PR TITLE
Changed the order of repositories lists

### DIFF
--- a/todoapp/build.gradle
+++ b/todoapp/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0'
@@ -13,8 +13,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }
 


### PR DESCRIPTION
Fixes the following error:
`ERROR: Could not find manifest-merger.jar (com.android.tools.build:manifest-merger:26.0.0).`