### PR TITLE
Fix #574 - config changes bug with localized resources - No more AndroidViewModels

### DIFF
--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/ViewModelFactory.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/ViewModelFactory.java
@@ -75,16 +75,16 @@ public class ViewModelFactory extends ViewModelProvider.NewInstanceFactory {
     public <T extends ViewModel> T create(Class<T> modelClass) {
         if (modelClass.isAssignableFrom(StatisticsViewModel.class)) {
             //noinspection unchecked
-            return (T) new StatisticsViewModel(mApplication, mTasksRepository);
+            return (T) new StatisticsViewModel(mTasksRepository);
         } else if (modelClass.isAssignableFrom(TaskDetailViewModel.class)) {
             //noinspection unchecked
-            return (T) new TaskDetailViewModel(mApplication, mTasksRepository);
+            return (T) new TaskDetailViewModel(mTasksRepository);
         } else if (modelClass.isAssignableFrom(AddEditTaskViewModel.class)) {
             //noinspection unchecked
-            return (T) new AddEditTaskViewModel(mApplication, mTasksRepository);
+            return (T) new AddEditTaskViewModel(mTasksRepository);
         } else if (modelClass.isAssignableFrom(TasksViewModel.class)) {
             //noinspection unchecked
-            return (T) new TasksViewModel(mApplication, mTasksRepository);
+            return (T) new TasksViewModel(mTasksRepository);
         }
         throw new IllegalArgumentException("Unknown ViewModel class: " + modelClass.getName());
     }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/ViewModelFactory.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/ViewModelFactory.java
@@ -40,8 +40,6 @@ public class ViewModelFactory extends ViewModelProvider.NewInstanceFactory {
     @SuppressLint("StaticFieldLeak")
     private static volatile ViewModelFactory INSTANCE;
 
-    private final Application mApplication;
-
     private final TasksRepository mTasksRepository;
 
     public static ViewModelFactory getInstance(Application application) {
@@ -49,7 +47,7 @@ public class ViewModelFactory extends ViewModelProvider.NewInstanceFactory {
         if (INSTANCE == null) {
             synchronized (ViewModelFactory.class) {
                 if (INSTANCE == null) {
-                    INSTANCE = new ViewModelFactory(application,
+                    INSTANCE = new ViewModelFactory(
                             Injection.provideTasksRepository(application.getApplicationContext()));
                 }
             }
@@ -66,8 +64,7 @@ public class ViewModelFactory extends ViewModelProvider.NewInstanceFactory {
         INSTANCE = null;
     }
 
-    private ViewModelFactory(Application application, TasksRepository repository) {
-        mApplication = application;
+    private ViewModelFactory(TasksRepository repository) {
         mTasksRepository = repository;
     }
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.java
@@ -16,8 +16,6 @@
 
 package com.example.android.architecture.blueprints.todoapp.addedittask;
 
-import android.app.Application;
-
 import com.example.android.architecture.blueprints.todoapp.Event;
 import com.example.android.architecture.blueprints.todoapp.R;
 import com.example.android.architecture.blueprints.todoapp.data.Task;
@@ -26,9 +24,9 @@ import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepo
 
 import androidx.annotation.Nullable;
 import androidx.databinding.ObservableField;
-import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
 
 /**
  * ViewModel for the Add/Edit screen.
@@ -38,7 +36,7 @@ import androidx.lifecycle.MutableLiveData;
  * {@link com.example.android.architecture.blueprints.todoapp.statistics.StatisticsViewModel} for
  * how to deal with more complex scenarios.
  */
-public class AddEditTaskViewModel extends AndroidViewModel implements TasksDataSource.GetTaskCallback {
+public class AddEditTaskViewModel extends ViewModel implements TasksDataSource.GetTaskCallback {
 
     // Two-way databinding, exposing MutableLiveData
     public final MutableLiveData<String> title = new MutableLiveData<>();
@@ -63,9 +61,7 @@ public class AddEditTaskViewModel extends AndroidViewModel implements TasksDataS
 
     private boolean mTaskCompleted = false;
 
-    public AddEditTaskViewModel(Application context,
-                                TasksRepository tasksRepository) {
-        super(context);
+    public AddEditTaskViewModel(TasksRepository tasksRepository) {
         mTasksRepository = tasksRepository;
     }
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsViewModel.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsViewModel.java
@@ -16,10 +16,6 @@
 
 package com.example.android.architecture.blueprints.todoapp.statistics;
 
-import android.app.Application;
-import android.content.Context;
-
-import com.example.android.architecture.blueprints.todoapp.R;
 import com.example.android.architecture.blueprints.todoapp.data.Task;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksDataSource;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepository;
@@ -29,9 +25,9 @@ import java.util.List;
 import androidx.databinding.Bindable;
 import androidx.databinding.ObservableBoolean;
 import androidx.databinding.ObservableField;
-import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
 
 /**
  * Exposes the data to be used in the statistics screen.
@@ -41,15 +37,15 @@ import androidx.lifecycle.MutableLiveData;
  * whereas the {@link Bindable} getters allow us to add some logic to it. This is
  * preferable to having logic in the XML layout.
  */
-public class StatisticsViewModel extends AndroidViewModel {
+public class StatisticsViewModel extends ViewModel {
 
     private final MutableLiveData<Boolean> mDataLoading = new MutableLiveData<>();
 
     private final MutableLiveData<Boolean> mError = new MutableLiveData<>();
 
-    private final MutableLiveData<String> mActiveTasks = new MutableLiveData<>();
+    private final MutableLiveData<Integer> mActiveTasks = new MutableLiveData<>();
 
-    private final MutableLiveData<String> mCompletedTasks = new MutableLiveData<>();
+    private final MutableLiveData<Integer> mCompletedTasks = new MutableLiveData<>();
 
     private final MutableLiveData mEmpty = new MutableLiveData();
 
@@ -57,13 +53,9 @@ public class StatisticsViewModel extends AndroidViewModel {
 
     private int mNumberOfCompletedTasks = 0;
 
-    private final Context mContext;
-
     private final TasksRepository mTasksRepository;
 
-    public StatisticsViewModel(Application context, TasksRepository tasksRepository) {
-        super(context);
-        mContext = context;
+    public StatisticsViewModel(TasksRepository tasksRepository) {
         mTasksRepository = tasksRepository;
     }
 
@@ -101,11 +93,11 @@ public class StatisticsViewModel extends AndroidViewModel {
         return mError;
     }
 
-    public LiveData<String> getNumberOfActiveTasks() {
+    public MutableLiveData<Integer> getNumberOfActiveTasks() {
         return mActiveTasks;
     }
 
-    public LiveData<String> getNumberOfCompletedTasks() {
+    public MutableLiveData<Integer> getNumberOfCompletedTasks() {
         return mCompletedTasks;
     }
 
@@ -137,10 +129,8 @@ public class StatisticsViewModel extends AndroidViewModel {
     }
 
     private void updateDataBindingObservables() {
-        mCompletedTasks.setValue(
-                mContext.getString(R.string.statistics_completed_tasks, mNumberOfCompletedTasks));
-        mActiveTasks.setValue(
-                mContext.getString(R.string.statistics_active_tasks, mNumberOfActiveTasks));
+        mCompletedTasks.setValue(mNumberOfCompletedTasks);
+        mActiveTasks.setValue(mNumberOfActiveTasks);
         mEmpty.setValue(mNumberOfActiveTasks + mNumberOfCompletedTasks == 0);
         mDataLoading.setValue(false);
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.java
@@ -16,8 +16,6 @@
 
 package com.example.android.architecture.blueprints.todoapp.taskdetail;
 
-import android.app.Application;
-
 import com.example.android.architecture.blueprints.todoapp.Event;
 import com.example.android.architecture.blueprints.todoapp.R;
 import com.example.android.architecture.blueprints.todoapp.data.Task;
@@ -28,17 +26,17 @@ import com.example.android.architecture.blueprints.todoapp.tasks.TasksFragment;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.arch.core.util.Function;
-import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.Transformations;
+import androidx.lifecycle.ViewModel;
 
 
 /**
  * Listens to user actions from the list item in ({@link TasksFragment}) and redirects them to the
  * Fragment's actions listener.
  */
-public class TaskDetailViewModel extends AndroidViewModel implements TasksDataSource.GetTaskCallback {
+public class TaskDetailViewModel extends ViewModel implements TasksDataSource.GetTaskCallback {
 
     private final MutableLiveData<Task> mTask = new MutableLiveData<>();
 
@@ -64,8 +62,7 @@ public class TaskDetailViewModel extends AndroidViewModel implements TasksDataSo
                 }
             });
 
-    public TaskDetailViewModel(Application context, TasksRepository tasksRepository) {
-        super(context);
+    public TaskDetailViewModel(TasksRepository tasksRepository) {
         mTasksRepository = tasksRepository;
     }
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.java
@@ -16,10 +16,6 @@
 
 package com.example.android.architecture.blueprints.todoapp.tasks;
 
-import android.app.Application;
-import android.content.Context;
-import android.graphics.drawable.Drawable;
-
 import com.example.android.architecture.blueprints.todoapp.Event;
 import com.example.android.architecture.blueprints.todoapp.R;
 import com.example.android.architecture.blueprints.todoapp.addedittask.AddEditTaskActivity;
@@ -34,10 +30,10 @@ import java.util.List;
 import androidx.arch.core.util.Function;
 import androidx.databinding.BaseObservable;
 import androidx.databinding.Bindable;
-import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.Transformations;
+import androidx.lifecycle.ViewModel;
 
 
 /**
@@ -47,17 +43,17 @@ import androidx.lifecycle.Transformations;
  * property changes. This is done by assigning a {@link Bindable} annotation to the property's
  * getter method.
  */
-public class TasksViewModel extends AndroidViewModel {
+public class TasksViewModel extends ViewModel {
 
     private final MutableLiveData<List<Task>> mItems = new MutableLiveData<>();
 
     private final MutableLiveData<Boolean> mDataLoading = new MutableLiveData<>();
 
-    private final MutableLiveData<String> mCurrentFilteringLabel = new MutableLiveData<>();
+    private final MutableLiveData<Integer> mCurrentFilteringLabel = new MutableLiveData<>();
 
-    private final MutableLiveData<String> mNoTasksLabel = new MutableLiveData<>();
+    private final MutableLiveData<Integer> mNoTasksLabel = new MutableLiveData<>();
 
-    private final MutableLiveData<Drawable> mNoTaskIconRes = new MutableLiveData<>();
+    private final MutableLiveData<Integer> mNoTaskIconRes = new MutableLiveData<>();
 
     private final MutableLiveData<Boolean> mTasksAddViewVisible = new MutableLiveData<>();
 
@@ -74,8 +70,6 @@ public class TasksViewModel extends AndroidViewModel {
 
     private final MutableLiveData<Event<Object>> mNewTaskEvent = new MutableLiveData<>();
 
-    private final Context mContext; // To avoid leaks, this must be an Application Context.
-
     // This LiveData depends on another so we can use a transformation.
     public final LiveData<Boolean> empty = Transformations.map(mItems,
             new Function<List<Task>, Boolean>() {
@@ -86,11 +80,7 @@ public class TasksViewModel extends AndroidViewModel {
                 }
             });
 
-    public TasksViewModel(
-            Application context,
-            TasksRepository repository) {
-        super(context);
-        mContext = context.getApplicationContext(); // Force use of Application Context.
+    public TasksViewModel(TasksRepository repository) {
         mTasksRepository = repository;
 
         // Set initial state
@@ -118,24 +108,21 @@ public class TasksViewModel extends AndroidViewModel {
         // Depending on the filter type, set the filtering label, icon drawables, etc.
         switch (requestType) {
             case ALL_TASKS:
-                mCurrentFilteringLabel.setValue(mContext.getString(R.string.label_all));
-                mNoTasksLabel.setValue(mContext.getResources().getString(R.string.no_tasks_all));
-                mNoTaskIconRes.setValue(mContext.getResources().getDrawable(
-                        R.drawable.ic_assignment_turned_in_24dp));
+                mCurrentFilteringLabel.setValue(R.string.label_all);
+                mNoTasksLabel.setValue(R.string.no_tasks_all);
+                mNoTaskIconRes.setValue(R.drawable.ic_assignment_turned_in_24dp);
                 mTasksAddViewVisible.setValue(true);
                 break;
             case ACTIVE_TASKS:
-                mCurrentFilteringLabel.setValue(mContext.getString(R.string.label_active));
-                mNoTasksLabel.setValue(mContext.getResources().getString(R.string.no_tasks_active));
-                mNoTaskIconRes.setValue(mContext.getResources().getDrawable(
-                        R.drawable.ic_check_circle_24dp));
+                mCurrentFilteringLabel.setValue(R.string.label_active);
+                mNoTasksLabel.setValue(R.string.no_tasks_active);
+                mNoTaskIconRes.setValue(R.drawable.ic_check_circle_24dp);
                 mTasksAddViewVisible.setValue(false);
                 break;
             case COMPLETED_TASKS:
-                mCurrentFilteringLabel.setValue(mContext.getString(R.string.label_completed));
-                mNoTasksLabel.setValue(mContext.getResources().getString(R.string.no_tasks_completed));
-                mNoTaskIconRes.setValue(mContext.getResources().getDrawable(
-                        R.drawable.ic_verified_user_24dp));
+                mCurrentFilteringLabel.setValue(R.string.label_completed);
+                mNoTasksLabel.setValue(R.string.no_tasks_completed);
+                mNoTaskIconRes.setValue(R.drawable.ic_verified_user_24dp);
                 mTasksAddViewVisible.setValue(false);
                 break;
         }
@@ -169,15 +156,15 @@ public class TasksViewModel extends AndroidViewModel {
         return mDataLoading;
     }
 
-    public LiveData<String> getCurrentFilteringLabel() {
+    public MutableLiveData<Integer> getCurrentFilteringLabel() {
         return mCurrentFilteringLabel;
     }
 
-    public LiveData<String> getNoTasksLabel() {
+    public MutableLiveData<Integer> getNoTasksLabel() {
         return mNoTasksLabel;
     }
 
-    public LiveData<Drawable> getNoTaskIconRes() {
+    public MutableLiveData<Integer> getNoTaskIconRes() {
         return mNoTaskIconRes;
     }
 

--- a/todoapp/app/src/main/res/layout/statistics_frag.xml
+++ b/todoapp/app/src/main/res/layout/statistics_frag.xml
@@ -57,14 +57,14 @@
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@{stats.numberOfActiveTasks}"
+                android:text="@{@string/statistics_active_tasks(stats.numberOfActiveTasks)}"
                 android:textAppearance="?android:attr/textAppearanceMedium"
                 android:visibility="@{stats.empty ? View.GONE : View.VISIBLE}" />
 
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@{stats.numberOfCompletedTasks}"
+                android:text="@{@string/statistics_completed_tasks(stats.numberOfCompletedTasks)}"
                 android:textAppearance="?android:attr/textAppearanceMedium"
                 android:visibility="@{stats.empty ? View.GONE : View.VISIBLE}" />
 

--- a/todoapp/app/src/main/res/layout/tasks_frag.xml
+++ b/todoapp/app/src/main/res/layout/tasks_frag.xml
@@ -20,6 +20,8 @@
 
         <import type="android.view.View" />
 
+        <import type="androidx.core.content.ContextCompat" />
+
         <variable
             name="viewmodel"
             type="com.example.android.architecture.blueprints.todoapp.tasks.TasksViewModel" />
@@ -57,7 +59,7 @@
                     android:layout_marginRight="@dimen/list_item_padding"
                     android:layout_marginTop="@dimen/activity_vertical_margin"
                     android:layout_marginBottom="@dimen/activity_vertical_margin"
-                    android:text="@{viewmodel.currentFilteringLabel}" />
+                    android:text="@{context.getString(viewmodel.currentFilteringLabel)}" />
 
                 <ListView
                     android:id="@+id/tasks_list"
@@ -79,14 +81,14 @@
                     android:layout_width="48dp"
                     android:layout_height="48dp"
                     android:layout_gravity="center"
-                    android:src="@{viewmodel.noTaskIconRes}" />
+                    android:src="@{ContextCompat.getDrawable(context, viewmodel.noTaskIconRes)}" />
 
                 <TextView
                     android:id="@+id/noTasksMain"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
-                    android:text="@{viewmodel.noTasksLabel}"
+                    android:text="@{context.getString(viewmodel.noTasksLabel)}"
                     android:layout_marginBottom="@dimen/list_item_padding"/>
 
                 <TextView

--- a/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModelTest.java
+++ b/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModelTest.java
@@ -17,15 +17,6 @@
 package com.example.android.architecture.blueprints.todoapp.addedittask;
 
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-
-import android.app.Application;
-
 import com.example.android.architecture.blueprints.todoapp.data.Task;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksDataSource;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepository;
@@ -39,6 +30,12 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
 
 /**
  * Unit tests for the implementation of {@link AddEditTaskViewModel}.
@@ -68,8 +65,7 @@ public class AddEditTaskViewModelTest {
         MockitoAnnotations.initMocks(this);
 
         // Get a reference to the class under test
-        mAddEditTaskViewModel = new AddEditTaskViewModel(
-                mock(Application.class), mTasksRepository);
+        mAddEditTaskViewModel = new AddEditTaskViewModel(mTasksRepository);
     }
 
     @Test
@@ -88,8 +84,7 @@ public class AddEditTaskViewModelTest {
         Task testTask = new Task("TITLE", "DESCRIPTION", "1");
 
         // Get a reference to the class under test
-        mAddEditTaskViewModel = new AddEditTaskViewModel(
-                mock(Application.class), mTasksRepository);
+        mAddEditTaskViewModel = new AddEditTaskViewModel(mTasksRepository);
 
 
         // When the ViewModel is asked to populate an existing task

--- a/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsViewModelTest.java
+++ b/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsViewModelTest.java
@@ -17,14 +17,6 @@
 package com.example.android.architecture.blueprints.todoapp.statistics;
 
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-
-import android.app.Application;
-
 import com.example.android.architecture.blueprints.todoapp.data.Task;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksDataSource;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepository;
@@ -41,6 +33,11 @@ import org.mockito.MockitoAnnotations;
 import java.util.List;
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
 
 /**
  * Unit tests for the implementation of {@link StatisticsViewModel}
@@ -68,7 +65,7 @@ public class StatisticsViewModelTest {
         MockitoAnnotations.initMocks(this);
 
         // Get a reference to the class under test
-        mStatisticsViewModel = new StatisticsViewModel(mock(Application.class), mTasksRepository);
+        mStatisticsViewModel = new StatisticsViewModel(mTasksRepository);
 
         // We initialise the tasks to 3, with one active and two completed
         TASKS = Lists.newArrayList(new Task("Title1", "Description1"),

--- a/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModelTest.java
+++ b/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModelTest.java
@@ -17,17 +17,6 @@
 package com.example.android.architecture.blueprints.todoapp.taskdetail;
 
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import android.app.Application;
 import android.content.res.Resources;
 
@@ -48,6 +37,16 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for the implementation of {@link TaskDetailViewModel}
@@ -72,12 +71,6 @@ public class TaskDetailViewModelTest {
     @Mock
     private Application mContext;
 
-    @Mock
-    private TasksDataSource.GetTaskCallback mRepositoryCallback;
-
-    @Mock
-    private TasksDataSource.GetTaskCallback mViewModelCallback;
-
     @Captor
     private ArgumentCaptor<TasksDataSource.GetTaskCallback> mGetTaskCallbackCaptor;
 
@@ -96,7 +89,7 @@ public class TaskDetailViewModelTest {
         mTask = new Task(TITLE_TEST, DESCRIPTION_TEST);
 
         // Get a reference to the class under test
-        mTaskDetailViewModel = new TaskDetailViewModel(mContext, mTasksRepository);
+        mTaskDetailViewModel = new TaskDetailViewModel(mTasksRepository);
     }
 
     private void setupContext() {
@@ -159,8 +152,6 @@ public class TaskDetailViewModelTest {
     @Test
     public void TaskDetailViewModel_repositoryError() throws InterruptedException {
         // Given an initialized ViewModel with an active task
-        mViewModelCallback = mock(TasksDataSource.GetTaskCallback.class);
-
         mTaskDetailViewModel.start(mTask.getId());
 
         // Use a captor to get a reference for the callback.
@@ -189,8 +180,6 @@ public class TaskDetailViewModelTest {
 
     private void setupViewModelRepositoryCallback() {
         // Given an initialized ViewModel with an active task
-        mViewModelCallback = mock(TasksDataSource.GetTaskCallback.class);
-
         mTaskDetailViewModel.start(mTask.getId());
 
         // Use a captor to get a reference for the callback.

--- a/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModelTest.java
+++ b/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModelTest.java
@@ -16,17 +16,6 @@
 
 package com.example.android.architecture.blueprints.todoapp.tasks;
 
-import static com.example.android.architecture.blueprints.todoapp.R.string.successfully_deleted_task_message;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import android.app.Application;
 import android.content.res.Resources;
 
@@ -52,6 +41,16 @@ import org.mockito.MockitoAnnotations;
 import java.util.List;
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+
+import static com.example.android.architecture.blueprints.todoapp.R.string.successfully_deleted_task_message;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for the implementation of {@link TasksViewModel}
@@ -84,7 +83,7 @@ public class TasksViewModelTest {
         setupContext();
 
         // Get a reference to the class under test
-        mTasksViewModel = new TasksViewModel(mContext, mTasksRepository);
+        mTasksViewModel = new TasksViewModel(mTasksRepository);
 
         // We initialise the tasks to 3, with one active and two completed
         TASKS = Lists.newArrayList(new Task("Title1", "Description1"),


### PR DESCRIPTION
Exposing resolved resources from ViewModels is not a good idea because they survive configuration changes, including locale changes.  See #574 and https://issuetracker.google.com/issues/111961971

In this PR we leverage Data Binding to load those resources for us with the nice side-effect of removing the need for AndroidViewModels so no context is available in them. (I'm considering moving AndroidViewModels to the smell category.)