### PR TITLE
Using static @Provides methods for stateless Modules

### DIFF
--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/di/ApplicationModule.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/di/ApplicationModule.kt
@@ -35,7 +35,7 @@ import kotlin.annotation.AnnotationRetention.RUNTIME
 
 
 @Module(includes = [ApplicationModuleBinds::class])
-class ApplicationModule {
+object ApplicationModule {
 
     @Qualifier
     @Retention(RUNTIME)
@@ -45,6 +45,7 @@ class ApplicationModule {
     @Retention(RUNTIME)
     annotation class TasksLocalDataSource
 
+    @JvmStatic
     @Singleton
     @TasksRemoteDataSource
     @Provides
@@ -52,6 +53,7 @@ class ApplicationModule {
         return TasksRemoteDataSource
     }
 
+    @JvmStatic
     @Singleton
     @TasksLocalDataSource
     @Provides
@@ -64,6 +66,7 @@ class ApplicationModule {
         )
     }
 
+    @JvmStatic
     @Singleton
     @Provides
     fun provideDataBase(context: Context): ToDoDatabase {
@@ -74,6 +77,7 @@ class ApplicationModule {
         ).build()
     }
 
+    @JvmStatic
     @Singleton
     @Provides
     fun provideIoDispatcher() = Dispatchers.IO


### PR DESCRIPTION
Since ApplicationModule is stateless, we could make all `@Provides` methods static. 

This will improve performance: an instance of this module is no longer required when providing these objects (you can see it in the generated code). The ApplicationComponent will call the static methods of this class directly without having to pass an instance of ApplicationModule in.