### PR TITLE
fix: show save button on New task screen when keyboard is displayed

### DIFF
--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskScreen.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskScreen.kt
@@ -20,13 +20,11 @@ package com.example.android.architecture.blueprints.todoapp.addedittask
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -72,7 +70,7 @@ fun AddEditTaskScreen(
     Scaffold(
         modifier = modifier
             .fillMaxSize()
-            .windowInsetsPadding(WindowInsets.ime),
+            .imePadding(),
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = { AddEditTaskTopAppBar(topBarTitle, onBack) },
         floatingActionButton = {

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskScreen.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskScreen.kt
@@ -20,10 +20,13 @@ package com.example.android.architecture.blueprints.todoapp.addedittask
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -67,7 +70,9 @@ fun AddEditTaskScreen(
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() }
 ) {
     Scaffold(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.ime),
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = { AddEditTaskTopAppBar(topBarTitle, onBack) },
         floatingActionButton = {


### PR DESCRIPTION
**Title:** On "New Task" screen when the keyboard is opened, "Save" floating action button is hidden behind the keyboard and it makes it difficult to save a task. 

**Steps:** 
1. Open app 
2. Click on "+" FAB
3. Click on Title input field, and enter title 
4. Click on Task details field, and enter description  

**Expected Result:** Save FAB button shouldn't be hidden behind the keyboard. 
**Actual Result:** Save FAB button is hidden behind the keyboard. 

**Before fix** 

https://github.com/user-attachments/assets/de6f553e-c46f-4f9d-b2ae-a6724966dfe2

**After fix**

https://github.com/user-attachments/assets/701ec4bf-851c-4a32-879d-4f87cbd6840b


 