### PR TITLE
Fix: prevent repeated snackbar messages by migrating state to TasksViewModel

### DIFF
--- a/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksScreenTest.kt
+++ b/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksScreenTest.kt
@@ -259,8 +259,6 @@ class TasksScreenTest {
                 Surface {
                     TasksScreen(
                         viewModel = TasksViewModel(repository, SavedStateHandle()),
-                        userMessage = R.string.successfully_added_task_message,
-                        onUserMessageDisplayed = { },
                         onAddTask = { },
                         onTaskClick = { },
                         openDrawer = { }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/TodoNavGraph.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/TodoNavGraph.kt
@@ -67,11 +67,9 @@ fun TodoNavGraph(
             arguments = listOf(
                 navArgument(USER_MESSAGE_ARG) { type = NavType.IntType; defaultValue = 0 }
             )
-        ) { entry ->
+        ) {
             AppModalDrawer(drawerState, currentRoute, navActions) {
                 TasksScreen(
-                    userMessage = entry.arguments?.getInt(USER_MESSAGE_ARG)!!,
-                    onUserMessageDisplayed = { entry.arguments?.putInt(USER_MESSAGE_ARG, 0) },
                     onAddTask = { navActions.navigateToAddEditTask(R.string.add_task, null) },
                     onTaskClick = { task -> navActions.navigateToTaskDetail(task.id) },
                     openDrawer = { coroutineScope.launch { drawerState.open() } }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksScreen.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksScreen.kt
@@ -44,7 +44,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
@@ -66,10 +65,8 @@ import com.example.android.architecture.blueprints.todoapp.util.TasksTopAppBar
 
 @Composable
 fun TasksScreen(
-    @StringRes userMessage: Int,
     onAddTask: () -> Unit,
     onTaskClick: (Task) -> Unit,
-    onUserMessageDisplayed: () -> Unit,
     openDrawer: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: TasksViewModel = hiltViewModel(),
@@ -114,15 +111,6 @@ fun TasksScreen(
             LaunchedEffect(snackbarHostState, viewModel, message, snackbarText) {
                 snackbarHostState.showSnackbar(snackbarText)
                 viewModel.snackbarMessageShown()
-            }
-        }
-
-        // Check if there's a userMessage to show to the user
-        val currentOnUserMessageDisplayed by rememberUpdatedState(onUserMessageDisplayed)
-        LaunchedEffect(userMessage) {
-            if (userMessage != 0) {
-                viewModel.showEditResultMessage(userMessage)
-                currentOnUserMessageDisplayed()
             }
         }
     }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.kt
@@ -102,7 +102,7 @@ class TasksViewModel @Inject constructor(
 
     init {
         // Read userMessageArgs from saveStateHandle
-        savedStateHandle.get<Int>(USER_MESSAGE_ARG)?.let { result ->
+        savedStateHandle.get<Int>(USER_MESSAGE_ARG)?.takeIf { it != 0 }?.let { result ->
             showEditResultMessage(result)
             savedStateHandle[USER_MESSAGE_ARG] = 0
         }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.kt
@@ -23,6 +23,7 @@ import com.example.android.architecture.blueprints.todoapp.ADD_EDIT_RESULT_OK
 import com.example.android.architecture.blueprints.todoapp.DELETE_RESULT_OK
 import com.example.android.architecture.blueprints.todoapp.EDIT_RESULT_OK
 import com.example.android.architecture.blueprints.todoapp.R
+import com.example.android.architecture.blueprints.todoapp.TodoDestinationsArgs.USER_MESSAGE_ARG
 import com.example.android.architecture.blueprints.todoapp.data.Task
 import com.example.android.architecture.blueprints.todoapp.data.TaskRepository
 import com.example.android.architecture.blueprints.todoapp.tasks.TasksFilterType.ACTIVE_TASKS
@@ -98,6 +99,14 @@ class TasksViewModel @Inject constructor(
             started = WhileUiSubscribed,
             initialValue = TasksUiState(isLoading = true)
         )
+
+    init {
+        // Read userMessageArgs from saveStateHandle
+        savedStateHandle.get<Int>(USER_MESSAGE_ARG)?.let { result ->
+            showEditResultMessage(result)
+            savedStateHandle[USER_MESSAGE_ARG] = 0
+        }
+    }
 
     fun setFiltering(requestType: TasksFilterType) {
         savedStateHandle[TASKS_FILTER_SAVED_STATE_KEY] = requestType


### PR DESCRIPTION
This PR fix a bug where Snackbar messages (such as "Task Saved") would reappear when navigating back to the TasksScreen or during configuration changes.

The root cause was the manual management of navigation arguments within the UI layer. Passing the userMessage through the TasksScreen composable and attempting to reset it via a callback was never succeed, because it can't be update.