### PR TITLE
Fix clear completed tasks being undone by immediate refresh

### DIFF
--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.kt
@@ -107,7 +107,6 @@ class TasksViewModel @Inject constructor(
         viewModelScope.launch {
             taskRepository.clearCompletedTasks()
             showSnackbarMessage(R.string.completed_tasks_cleared)
-            refresh()
         }
     }
 

--- a/app/src/test/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModelTest.kt
+++ b/app/src/test/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModelTest.kt
@@ -144,12 +144,11 @@ class TasksViewModelTest {
         // When completed tasks are cleared
         tasksViewModel.clearCompletedTasks()
 
-        // Fetch tasks
-        tasksViewModel.refresh()
+        advanceUntilIdle()
 
-        // Fetch tasks
-        val allTasks = tasksViewModel.uiState.first().items
-        val completedTasks = allTasks?.filter { it.isCompleted }
+        val uiState = tasksViewModel.uiState.first { !it.isLoading }
+        val allTasks = uiState.items
+        val completedTasks = allTasks.filter { it.isCompleted }
 
         // Verify there are no completed tasks left
         assertThat(completedTasks).isEmpty()
@@ -158,8 +157,7 @@ class TasksViewModelTest {
         assertThat(allTasks).hasSize(1)
 
         // Verify snackbar is updated
-        assertThat(tasksViewModel.uiState.first().userMessage)
-            .isEqualTo(R.string.completed_tasks_cleared)
+        assertThat(uiState.userMessage).isEqualTo(R.string.completed_tasks_cleared)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Remove unnecessary `refresh()` after `clearCompletedTasks()` in `TasksViewModel`.
- The task list already updates via Room `Flow`.
- An immediate full refresh can reload stale network data before `saveTasksToNetwork()` finishes (the fake network has a 2s delay), which can restore completed tasks the user just cleared.

## Test plan

- [x] `:app:testDebugUnitTest` (`TasksViewModelTest`)
- [ ] Manual: complete tasks, Clear completed from menu, verify completed tasks stay cleared
